### PR TITLE
Added LilyGo T-CAN485 board example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A telegram from the heat pump must be acknowledged, otherwise the heat pump will
 
 You will need an esp32 with some type of RS485 converter hooked up to a UART. It can either be a MAX485 based chip or a chip with automatic flow control like a MAX3485. If using an automatic flow controlling chip, set the `dir_pin` to an unused GPIO pin on your board.
 
+An example of such a board is the [LilyGo T-CAN485](https://github.com/Xinyuan-LilyGO/T-CAN485), this board has an integrated RS485 connection that is verified to work with this setup. An example setup can be found in the [examples](./examples) folder.
+
+
 ### Configuration example
 
 Add the following to a ESPHome configuration to enable the udp gateway feature to the device.

--- a/examples/lilygo-t-can485.yaml
+++ b/examples/lilygo-t-can485.yaml
@@ -1,0 +1,75 @@
+esphome:
+  name: nibegw
+  comment: Nibegw
+  platform: ESP32
+  board: esp32dev
+  platformio_options:
+    board_build.partitions: huge_app.csv # Required to set partition sizes
+
+# General ESPHome setup
+api:
+
+ota:
+  password: !secret OTA_PASSWORD
+
+wifi:
+  ssid: !secret WIFI_SSID
+  password: !secret WIFI_PASSWORD
+  fast_connect: true # Fast connect to connect to my hidden network
+
+# Load nibe component
+external_components:
+  - source: github://elupus/esphome-nibe
+
+# Set pins required for LilyGo T-CAN485 board
+output:
+  - platform: gpio
+    id: ENABLE_PIN # Enable the chip
+    pin:
+      number: GPIO19
+      inverted: true
+  - platform: gpio
+    id: SE_PIN # Enable autodirection
+    pin:
+      number: GPIO17
+      inverted: true
+  - platform: gpio
+    id: ENABLE_5V_PIN # Enable 5V pin for RS485 chip
+    pin:
+      number: GPIO16
+      inverted: true
+
+# Configure NibeGW
+nibegw:
+  dir_pin: GPIO25
+  rx_pin: GPIO21
+  tx_pin: GPIO22
+  udp:
+    # The target address(s) to send data to. May be a multicast address.
+    target:
+      - ip: 192.168.255.254
+        port: 10090
+
+    # List of source address to accept data from, may be empty for no filter
+    source:
+      - 192.168.255.254
+
+  acknowledge:
+    - MODBUS40
+
+  # Constant replies to certain requests cabe made
+  constants:
+    - address: MODBUS40
+      token: ACCESSORY
+      data: [
+            0x0A, # MODBUS version low
+            0x00, # MODBUS version high
+            0x01, # MODBUS address?
+      ]
+
+# Some helper functions to restart ESPHome from HA
+button:
+- platform: restart
+  name: Nibegw Restart
+- platform: safe_mode
+  name: Nibegw Safe Mode Boot


### PR DESCRIPTION
As mentioned in https://github.com/elupus/esphome-nibe/issues/2, I've created a full working ESPHome example file for this board.