### PR TITLE
Switch to esphome native uart and gpio config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ uart:
   baud_rate: 9600
 
 nibegw:
-  dir_pin: GPIO4
   udp:
     target:
       - ip: 192.168.16.130
@@ -62,7 +61,9 @@ uart:
   baud_rate: 9600
 
 nibegw:
-  dir_pin: GPIO4
+  dir_pin:
+    number: GPIO4
+    invert: false
 
   # If you have a named uart instance, you can specify this here.
   uart_id: my_uart

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A telegram from the heat pump must be acknowledged, otherwise the heat pump will
 
 ## Setup
 
-You will need an esp32 with some type of RS485 converter hooked up to a UART. It can either be a MAX485 based chip or a chip with automatic flow control like a MAX3485. If using an automatic flow controlling chip, set the `dir_pin` to an unused GPIO pin on your board.
+You will need an esp32 with some type of RS485 converter hooked up to a UART. It can either be a MAX485 based chip or a chip with automatic flow control like a MAX3485. If using an automatic flow controlling chip, don't set the `dir_pin`.
 
 An example of such a board is the [LilyGo T-CAN485](https://github.com/Xinyuan-LilyGO/T-CAN485), this board has an integrated RS485 connection that is verified to work with this setup. An example setup can be found in the [examples](./examples) folder.
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ external_components:
       url: https://github.com/elupus/esphome-nibe.git
     components: [ nibegw ]
 
-nibegw:
-  dir_pin: GPIO4
+uart:
   rx_pin: GPIO16
   tx_pin: GPIO17
-  uart_id: 1
+  baud_rate: 9600
+
+nibegw:
+  dir_pin: GPIO4
   udp:
     target:
       - ip: 192.168.16.130
@@ -53,11 +55,18 @@ external_components:
       url: https://github.com/elupus/esphome-nibe.git
     components: [ nibegw ]
 
-nibegw:
-  dir_pin: GPIO4
+uart:
+  id: my_uart
   rx_pin: GPIO16
   tx_pin: GPIO17
-  uart_id: 1
+  baud_rate: 9600
+
+nibegw:
+  dir_pin: GPIO4
+
+  # If you have a named uart instance, you can specify this here.
+  uart_id: my_uart
+
   udp:
     # The target address(s) to send data to. May also be multicast addresses.
     target:

--- a/components/nibegw/NibeGw.cpp
+++ b/components/nibegw/NibeGw.cpp
@@ -17,9 +17,10 @@
  */
 
 #include "NibeGw.h"
+#include "esphome/core/gpio.h"
 #include "esphome/components/uart/uart.h"
 
-NibeGw::NibeGw(esphome::uart::UARTDevice* serial, int RS485DirectionPin)
+NibeGw::NibeGw(esphome::uart::UARTDevice* serial, esphome::GPIOPin* RS485DirectionPin)
 {
   verbose = 0;
   sendAcknowledge = true;
@@ -27,8 +28,6 @@ NibeGw::NibeGw(esphome::uart::UARTDevice* serial, int RS485DirectionPin)
   connectionState = false;
   RS485 = serial;
   directionPin = RS485DirectionPin;
-  pinMode(directionPin, OUTPUT);
-  digitalWrite(directionPin, LOW);
   setCallback(NULL, NULL);
 }
 
@@ -301,12 +300,13 @@ void NibeGw::sendData(const byte* const data, byte len)
   }
 #endif
 
-  digitalWrite(directionPin, HIGH);
-  delay(1);
+  if(directionPin)
+    directionPin->digital_write(true);
   RS485->write_array(data, len);
   RS485->flush();
   delay(1);
-  digitalWrite(directionPin, LOW);
+  if(directionPin)
+    directionPin->digital_write(false);
 }
 
 void NibeGw::sendAck()
@@ -316,12 +316,14 @@ void NibeGw::sendAck()
     debug(1, "Send ACK\n");
 #endif
 
-  digitalWrite(directionPin, HIGH);
+  if(directionPin)
+    directionPin->digital_write(true);
   delay(1);
   RS485->write_byte(0x06);
   RS485->flush();
   delay(1);
-  digitalWrite(directionPin, LOW);
+  if(directionPin)
+    directionPin->digital_write(false);
 }
 
 void NibeGw::sendNak()
@@ -331,12 +333,14 @@ void NibeGw::sendNak()
     debug(1, "Send NACK\n");
 #endif
 
-  digitalWrite(directionPin, HIGH);
+  if(directionPin)
+    directionPin->digital_write(true);
   delay(1);
   RS485->write(0x15);
   RS485->flush();
   delay(1);
-  digitalWrite(directionPin, LOW);
+  if(directionPin)
+    directionPin->digital_write(false);
 }
 
 boolean NibeGw::shouldAckNakSend(byte address)

--- a/components/nibegw/NibeGw.cpp
+++ b/components/nibegw/NibeGw.cpp
@@ -17,20 +17,10 @@
  */
 
 #include "NibeGw.h"
-#include "Arduino.h"
+#include "esphome/components/uart/uart.h"
 
-#if defined(HARDWARE_SERIAL_WITH_PINS)
-NibeGw::NibeGw(HardwareSerial* serial, int RS485DirectionPin, int RS485RxPin, int RS485TxPin)
-#elif defined(HARDWARE_SERIAL)
-NibeGw::NibeGw(HardwareSerial* serial, int RS485DirectionPin)
-#else
-NibeGw::NibeGw(Serial_* serial, int RS485DirectionPin)
-#endif
+NibeGw::NibeGw(esphome::uart::UARTDevice* serial, int RS485DirectionPin)
 {
-  #if defined(HARDWARE_SERIAL_WITH_PINS)
-    this->RS485RxPin = RS485RxPin;
-    this->RS485TxPin = RS485TxPin;
-  #endif  
   verbose = 0;
   sendAcknowledge = true;
   state = STATE_WAIT_START;
@@ -47,13 +37,6 @@ void NibeGw::connect()
   if (!connectionState)
   {
     state = STATE_WAIT_START;
-    
-    #if defined(HARDWARE_SERIAL_WITH_PINS)
-      RS485->begin(9600, SERIAL_8N1, RS485RxPin, RS485TxPin);
-    #else
-      RS485->begin(9600, SERIAL_8N1);
-    #endif
-    
     connectionState = true;
   }
 }
@@ -62,7 +45,6 @@ void NibeGw::disconnect()
 {
   if (connectionState)
   {
-    RS485->end();
     connectionState = false;
   }
 }
@@ -321,7 +303,7 @@ void NibeGw::sendData(const byte* const data, byte len)
 
   digitalWrite(directionPin, HIGH);
   delay(1);
-  RS485->write(data, len);
+  RS485->write_array(data, len);
   RS485->flush();
   delay(1);
   digitalWrite(directionPin, LOW);
@@ -336,7 +318,7 @@ void NibeGw::sendAck()
 
   digitalWrite(directionPin, HIGH);
   delay(1);
-  RS485->write(0x06);
+  RS485->write_byte(0x06);
   RS485->flush();
   delay(1);
   digitalWrite(directionPin, LOW);

--- a/components/nibegw/NibeGw.h
+++ b/components/nibegw/NibeGw.h
@@ -38,6 +38,7 @@
 
 #include <Arduino.h>
 #include "esphome/components/uart/uart.h"
+#include "esphome/core/gpio.h"
 #include <functional>
 #include <set>
 
@@ -83,7 +84,7 @@ class NibeGw
   private:
     eState state;
     boolean connectionState;
-    byte directionPin;
+    esphome::GPIOPin* directionPin;
     byte buffer[MAX_DATA_LEN];
     byte index;
     esphome::uart::UARTDevice* RS485;
@@ -105,7 +106,7 @@ class NibeGw
     #endif
 
   public:
-    NibeGw(esphome::uart::UARTDevice* serial, int RS485DirectionPin);
+    NibeGw(esphome::uart::UARTDevice* serial, esphome::GPIOPin* RS485DirectionPin);
     NibeGw& setCallback(callback_msg_received_type callback_msg_received, callback_msg_token_received_type callback_msg_token_received);
 
     #ifdef ENABLE_NIBE_DEBUG

--- a/components/nibegw/NibeGw.h
+++ b/components/nibegw/NibeGw.h
@@ -37,6 +37,7 @@
 #define NibeGw_h
 
 #include <Arduino.h>
+#include "esphome/components/uart/uart.h"
 #include <functional>
 #include <set>
 
@@ -85,15 +86,7 @@ class NibeGw
     byte directionPin;
     byte buffer[MAX_DATA_LEN];
     byte index;
-    #if defined(HARDWARE_SERIAL_WITH_PINS)
-      HardwareSerial* RS485;
-      int RS485RxPin;
-      int RS485TxPin;
-    #elif defined(HARDWARE_SERIAL)
-      HardwareSerial* RS485;
-    #else
-      Serial_* RS485;
-    #endif
+    esphome::uart::UARTDevice* RS485;
     callback_msg_received_type callback_msg_received;
     callback_msg_token_received_type callback_msg_token_received;
     byte verbose;
@@ -112,13 +105,7 @@ class NibeGw
     #endif
 
   public:
-    #if defined(HARDWARE_SERIAL_WITH_PINS)
-      NibeGw(HardwareSerial* serial, int RS485DirectionPin, int RS485RxPin, int RS485TxPin);
-    #elif defined(HARDWARE_SERIAL)
-      NibeGw(HardwareSerial* serial, int RS485DirectionPin);
-    #else
-      NibeGw(Serial_* serial, int RS485DirectionPin);
-    #endif
+    NibeGw(esphome::uart::UARTDevice* serial, int RS485DirectionPin);
     NibeGw& setCallback(callback_msg_received_type callback_msg_received, callback_msg_token_received_type callback_msg_token_received);
 
     #ifdef ENABLE_NIBE_DEBUG

--- a/components/nibegw/NibeGwComponent.cpp
+++ b/components/nibegw/NibeGwComponent.cpp
@@ -1,16 +1,8 @@
 #include "NibeGwComponent.h"
 
-NibeGwComponent::NibeGwComponent(int uart_no, int dir_pin, int rx_pin, int tx_pin)
+NibeGwComponent::NibeGwComponent(int dir_pin)
 {
-#if defined(HARDWARE_SERIAL_WITH_PINS)
-    HardwareSerial* serial = new HardwareSerial(uart_no);
-    gw_ = new NibeGw(serial, dir_pin, rx_pin, tx_pin);
-#elif defined(HARDWARE_SERIAL)
-    HardwareSerial* serial = new HardwareSerial(uart_no);
-    gw_ = new NibeGw(serial, dir_pin);
-#else
-    gw_ = new NibeGw(&Serial, dir_pin);
-#endif
+    gw_ = new NibeGw(this, dir_pin);
     gw_->setCallback(std::bind(&NibeGwComponent::callback_msg_received, this, std::placeholders::_1, std::placeholders::_2),
                      std::bind(&NibeGwComponent::callback_msg_token_received, this, std::placeholders::_1, std::placeholders::_2));
 #ifdef ENABLE_NIBE_DEBUG

--- a/components/nibegw/NibeGwComponent.cpp
+++ b/components/nibegw/NibeGwComponent.cpp
@@ -1,6 +1,8 @@
 #include "NibeGwComponent.h"
 
-NibeGwComponent::NibeGwComponent(int dir_pin)
+using namespace esphome;
+
+NibeGwComponent::NibeGwComponent(esphome::GPIOPin* dir_pin)
 {
     gw_ = new NibeGw(this, dir_pin);
     gw_->setCallback(std::bind(&NibeGwComponent::callback_msg_received, this, std::placeholders::_1, std::placeholders::_2),

--- a/components/nibegw/NibeGwComponent.h
+++ b/components/nibegw/NibeGwComponent.h
@@ -7,9 +7,9 @@
 
 #include "esphome.h"
 #include "esphome/core/component.h"
+#include "esphome/components/uart/uart.h"
 
 #include "NibeGw.h"
-#include <HardwareSerial.h>
 
 
 #ifdef USE_ESP32
@@ -28,7 +28,7 @@ typedef std::tuple<byte, byte>  request_key_type;
 typedef std::vector<byte>       request_data_type;
 typedef std::tuple<network::IPAddress, int> target_type;
 
-class NibeGwComponent: public Component {
+class NibeGwComponent: public Component, public uart::UARTDevice {
     float get_setup_priority() const override { return setup_priority::BEFORE_CONNECTION; }
     const char* TAG = "nibegw";
     const int requests_queue_max = 3;
@@ -83,7 +83,7 @@ class NibeGwComponent: public Component {
 
     NibeGw& gw() { return *gw_; }
 
-    NibeGwComponent(int uart_no, int dir_pin, int rx_pin, int tx_pin);
+    NibeGwComponent(int dir_pin);
 
     void setup();
     void dump_config();

--- a/components/nibegw/NibeGwComponent.h
+++ b/components/nibegw/NibeGwComponent.h
@@ -7,6 +7,7 @@
 
 #include "esphome.h"
 #include "esphome/core/component.h"
+#include "esphome/core/gpio.h"
 #include "esphome/components/uart/uart.h"
 
 #include "NibeGw.h"
@@ -28,7 +29,7 @@ typedef std::tuple<byte, byte>  request_key_type;
 typedef std::vector<byte>       request_data_type;
 typedef std::tuple<network::IPAddress, int> target_type;
 
-class NibeGwComponent: public Component, public uart::UARTDevice {
+class NibeGwComponent: public esphome::Component, public esphome::uart::UARTDevice {
     float get_setup_priority() const override { return setup_priority::BEFORE_CONNECTION; }
     const char* TAG = "nibegw";
     const int requests_queue_max = 3;
@@ -83,7 +84,7 @@ class NibeGwComponent: public Component, public uart::UARTDevice {
 
     NibeGw& gw() { return *gw_; }
 
-    NibeGwComponent(int dir_pin);
+    NibeGwComponent(GPIOPin* dir_pin);
 
     void setup();
     void dump_config();

--- a/components/nibegw/__init__.py
+++ b/components/nibegw/__init__.py
@@ -5,19 +5,18 @@ import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import (
     CONF_ID,
-    CONF_RX_PIN,
-    CONF_TX_PIN,
-    CONF_UART_ID,
     CONF_DEBUG,
 )
 from esphome import pins
 from esphome.core import CORE
 from esphome.components.network import IPAddress
 from enum import IntEnum, Enum
+from esphome.components import uart
+
 
 DEPENDENCIES = ["logger"]
 
-NibeGwComponent = cg.global_ns.class_("NibeGwComponent", cg.Component)
+NibeGwComponent = cg.global_ns.class_("NibeGwComponent", cg.Component, uart.UARTDevice)
 
 CONF_DIR_PIN = "dir_pin"
 CONF_TARGET = "target"
@@ -93,25 +92,20 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(NibeGwComponent),
         cv.Optional(CONF_ACKNOWLEDGE, default=[]): [cv.Any(addresses_string, cv.Coerce(int))],
         cv.Required(CONF_UDP): UDP_SCHEMA,
-        cv.Optional(CONF_RX_PIN): pins.internal_gpio_input_pin_number,
-        cv.Optional(CONF_TX_PIN): pins.internal_gpio_output_pin_number,
         cv.Optional(CONF_DIR_PIN): pins.internal_gpio_output_pin_number,
-        cv.Optional(CONF_UART_ID, default=2): int,
         cv.Optional(CONF_DEBUG, default=False): cv.boolean,
         cv.Optional(CONF_CONSTANTS, default=[]): cv.ensure_list(CONSTANTS_SCHEMA)
     }
-).extend(cv.COMPONENT_SCHEMA)
+).extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
 
 
 async def to_code(config):
     var = cg.new_Pvariable(
         config[CONF_ID],
-        config[CONF_UART_ID],
         config[CONF_DIR_PIN],
-        config[CONF_RX_PIN],
-        config[CONF_TX_PIN],
     )
     await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
 
     if config[CONF_DEBUG]:
         cg.add_build_flag("-DENABLE_NIBE_DEBUG")

--- a/components/nibegw/__init__.py
+++ b/components/nibegw/__init__.py
@@ -92,7 +92,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(NibeGwComponent),
         cv.Optional(CONF_ACKNOWLEDGE, default=[]): [cv.Any(addresses_string, cv.Coerce(int))],
         cv.Required(CONF_UDP): UDP_SCHEMA,
-        cv.Optional(CONF_DIR_PIN): pins.internal_gpio_output_pin_number,
+        cv.Optional(CONF_DIR_PIN): pins.gpio_output_pin_schema,
         cv.Optional(CONF_DEBUG, default=False): cv.boolean,
         cv.Optional(CONF_CONSTANTS, default=[]): cv.ensure_list(CONSTANTS_SCHEMA)
     }
@@ -100,9 +100,14 @@ CONFIG_SCHEMA = cv.Schema(
 
 
 async def to_code(config):
+    if dir_pin := config.get(CONF_DIR_PIN):
+        dir_pin_data = await cg.gpio_pin_expression(dir_pin)
+    else:
+        dir_pin_data = 0
+
     var = cg.new_Pvariable(
         config[CONF_ID],
-        config[CONF_DIR_PIN],
+        dir_pin_data,
     )
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/examples/lilygo-t-can485.yaml
+++ b/examples/lilygo-t-can485.yaml
@@ -37,11 +37,13 @@ output:
       number: GPIO16
       inverted: true
 
-# Configure NibeGW
-nibegw:
-  dir_pin: GPIO25
+# Configure uart that will be used
+uart:
   rx_pin: GPIO21
   tx_pin: GPIO22
+
+# Configure NibeGW
+nibegw:
   udp:
     # The target address(s) to send data to. May be a multicast address.
     target:


### PR DESCRIPTION
## Breaking Change
* Standard uart config section, need to be configured.

# Changes
* Use standard uart config section (please see readme for new config)
* Use standard gpio pin config for direction pin