### PR TITLE
Checksum should include 16bit address

### DIFF
--- a/components/nibegw/NibeGw.cpp
+++ b/components/nibegw/NibeGw.cpp
@@ -254,7 +254,7 @@ int NibeGw::checkNibeMessage(const byte* const data, byte len)
       byte checksum = 0;
 
       // calculate XOR checksum
-      for (int i = 2; i < (datalen + 5); i++)
+      for (int i = 1; i < (datalen + 5); i++)
         checksum ^= data[i];
 
       byte msg_checksum = data[datalen + 5];


### PR DESCRIPTION

Related to: https://github.com/openhab/openhab-addons/issues/13684, https://github.com/home-assistant/core/issues/81748, https://github.com/yozik04/nibe/pull/65