### PR TITLE
Use AsyncUDP library

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ Add the following to a ESPHome configuration to enable the udp gateway feature t
 Minimal Config
 
 ```yaml
-esphome:
-  name: nibegw
-
 external_components:
   - source: 
       type: git

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Add the following to a ESPHome configuration to enable the udp gateway feature t
 Minimal Config
 
 ```yaml
+esphome:
+  name: nibegw
+  libraries:
+    - "ESP32 Async UDP"
+
 external_components:
   - source: 
       type: git

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ Minimal Config
 ```yaml
 esphome:
   name: nibegw
-  libraries:
-    - "ESP32 Async UDP"
 
 external_components:
   - source: 

--- a/components/nibegw/NibeGwComponent.cpp
+++ b/components/nibegw/NibeGwComponent.cpp
@@ -63,8 +63,7 @@ void NibeGwComponent::token_request_cache(AsyncUDPPacket& udp, byte address, byt
     }
 
     request_data_type request;
-    request.resize(size);
-    udp.read(&request[0], size);
+    request.assign(udp.data(), udp.data()+size);
     add_queued_request(address, token, std::move(request));
 }
 

--- a/components/nibegw/NibeGwComponent.cpp
+++ b/components/nibegw/NibeGwComponent.cpp
@@ -13,6 +13,12 @@ NibeGwComponent::NibeGwComponent(esphome::GPIOPin* dir_pin)
     gw_->setVerboseLevel(1);
 
 
+    udp_read_.onPacket([this](AsyncUDPPacket packet) {
+        token_request_cache(packet, MODBUS40, READ_TOKEN);
+    });
+    udp_write_.onPacket([this](AsyncUDPPacket packet) {
+        token_request_cache(packet, MODBUS40, WRITE_TOKEN);
+    });
 }
 
 void NibeGwComponent::callback_msg_received(const byte* const data, int len)
@@ -24,12 +30,7 @@ void NibeGwComponent::callback_msg_received(const byte* const data, int len)
     ESP_LOGD(TAG, "UDP Packet with %d bytes to send", len);
     for (auto target = udp_targets_.begin(); target != udp_targets_.end(); target++)
     {
-        udp_read_.beginPacket(
-            (uint32_t)std::get<0>(*target),
-            std::get<1>(*target)
-        );
-        udp_read_.write(data, len);
-        if (!udp_read_.endPacket()) {
+        if (!udp_read_.writeTo(data, len, (uint32_t)std::get<0>(*target), std::get<1>(*target))) {
             ESP_LOGW(TAG, "UDP Packet send failed to %s:%d",
                           std::get<0>(*target).str().c_str(),
                           std::get<1>(*target));
@@ -37,13 +38,13 @@ void NibeGwComponent::callback_msg_received(const byte* const data, int len)
     }
 }
 
-void NibeGwComponent::token_request_cache(WiFiUDP& udp, byte address, byte token)
+void NibeGwComponent::token_request_cache(AsyncUDPPacket& udp, byte address, byte token)
 {
     if (!is_connected_) {
         return;
     }
 
-    int size = udp.parsePacket();
+    int size = udp.length();
     if (size == 0) {
         return;
     }
@@ -138,20 +139,20 @@ void NibeGwComponent::loop()
 {
     if (network::is_connected() && !is_connected_) {
         ESP_LOGI(TAG, "Connecting network ports.");
-        udp_read_.begin(udp_read_port_);
-        udp_write_.begin(udp_write_port_);
+        udp_read_.listen(udp_read_port_);
+        udp_write_.listen(udp_write_port_);
         is_connected_ = true;
     }
 
     if (!network::is_connected() && is_connected_) {
         ESP_LOGI(TAG, "Disconnecting network ports.");
-        udp_read_.stop();
-        udp_write_.stop();
+        udp_read_.close();
+        udp_write_.close();
         is_connected_ = false;
     }
 
-    token_request_cache(udp_read_, MODBUS40, READ_TOKEN);
-    token_request_cache(udp_write_, MODBUS40, WRITE_TOKEN);
+    
+
     do {
         gw_->loop();
     } while(gw_->messageStillOnProgress());

--- a/components/nibegw/NibeGwComponent.h
+++ b/components/nibegw/NibeGwComponent.h
@@ -15,6 +15,7 @@
 
 #ifdef USE_ESP32
 #include <WiFi.h>
+#include "AsyncUDP.h"
 #endif
 
 #ifdef USE_ESP8266
@@ -44,14 +45,14 @@ class NibeGwComponent: public esphome::Component, public esphome::uart::UARTDevi
 
     NibeGw* gw_;
 
-    WiFiUDP udp_read_;
-    WiFiUDP udp_write_;
+    AsyncUDP udp_read_;
+    AsyncUDP udp_write_;
 
     void callback_msg_received(const byte* const data, int len);
     int callback_msg_token_received(eTokenType token, byte* data);
     void callback_debug(byte verbose, char* data);
 
-    void token_request_cache(WiFiUDP& udp, byte address, byte token);
+    void token_request_cache(AsyncUDPPacket& udp, byte address, byte token);
 
     public:
 

--- a/components/nibegw/NibeGwComponent.h
+++ b/components/nibegw/NibeGwComponent.h
@@ -20,7 +20,7 @@
 
 #ifdef USE_ESP8266
 #include <ESP8266WiFi.h>
-#include <WiFiUdp.h>
+#include "ESPAsyncUDP.h"
 #endif
 
 using namespace esphome;

--- a/components/nibegw/__init__.py
+++ b/components/nibegw/__init__.py
@@ -117,9 +117,11 @@ async def to_code(config):
 
     if CORE.is_esp32:
         cg.add_build_flag("-DHARDWARE_SERIAL_WITH_PINS")
+        cg.add_library("ESP32 Async UDP", None)
 
     if CORE.is_esp8266:
         cg.add_build_flag("-DHARDWARE_SERIAL")
+        cg.add_library("ESPAsyncUDP", None)
 
     if udp := config.get(CONF_UDP):
         for target in udp[CONF_TARGET]:


### PR DESCRIPTION
in an attempt to make UDP reception more stable.

I've had issues where suddenly the Nibe heatpump goes unavailable in Home Assistant. It seems to be due to the ESP32 stops receiving the UDP datagrams for single register readout.

I stole an older version of the AsyncUDP library from [espressif/arduino-esp32](https://github.com/espressif/arduino-esp32/tree/ce2cd111a150ca87ab733ae434d77962a7efe96f/libraries/AsyncUDP), because the latest version depends on an updated Espressif IDF.

I don't know how the PlatformIO LDF could be convinced to finding this library through other means, but for the POC I decided to just bundle it.

Let me know your thoughts.