### PR TITLE
Update lilygo-t-can485.yaml

### DIFF
--- a/examples/lilygo-t-can485.yaml
+++ b/examples/lilygo-t-can485.yaml
@@ -6,6 +6,7 @@ esphome:
 
 # General ESPHome setup
 api:
+  reboot_timeout: 0s
 
 ota:
   password: !secret OTA_PASSWORD


### PR DESCRIPTION
Add `reboot_timeout: 0s` to `api:` to prevent reboot when no client is connected (see https://esphome.io/components/api.html#configuration-variables). This solves reboots every 15 minutes and possibly lost modbus connection.