### PR TITLE
LilyGo T-CAN485 sample update

### DIFF
--- a/examples/lilygo-t-can485.yaml
+++ b/examples/lilygo-t-can485.yaml
@@ -17,6 +17,9 @@ wifi:
   ssid: !secret WIFI_SSID
   password: !secret WIFI_PASSWORD
   fast_connect: true # Fast connect to connect to my hidden network
+  # It is recommended to disable powersave mode on wifi, to make sure the device does not miss UDP requests sent.
+  power_save_mode: none
+  # The device needs a static IP. Either do that here with the manual_ip node, or do it via another way (router)
 
 # Load nibe component
 external_components:
@@ -50,13 +53,20 @@ uart:
 nibegw:
   udp:
     # The target address(s) to send data to. May be a multicast address.
+    # When using Home Assistant: this is your Home Assistant IP.
     target:
       - ip: 192.168.255.254
-        port: 10090
+        port: 9999
 
     # List of source address to accept data from, may be empty for no filter
     source:
       - 192.168.255.254
+
+    # Optional port this device will listen to to receive read requests. Defaults to 9999
+    # read_port: 9999
+
+    # Optional port this device will listen to to receive write request. Defaults to 10000
+    # write_port: 10000
 
   acknowledge:
     - MODBUS40

--- a/examples/lilygo-t-can485.yaml
+++ b/examples/lilygo-t-can485.yaml
@@ -56,7 +56,7 @@ nibegw:
     # When using Home Assistant: this is your Home Assistant IP.
     target:
       - ip: 192.168.255.254
-        port: 9999
+        port: 9999 #The Nibe Home Assistant integration listens to 9999 by default 
 
     # List of source address to accept data from, may be empty for no filter
     source:


### PR DESCRIPTION
While I'm a developer it still took me a bit of time to get going with the LilyGo T-CAN485. Hope it will takes less time of others with these hints.

So making the LilyGo T-CAN485 sample easier for first timers:

- The reamde.md recommends to disable WiFi powersave, also added that in the sample.
- The readme doesn't talk about a static IP, while it's quite practical to have that.
- I was a bit in the unclear that target address needs to go to home assistant. Didn't expect the UDP listener in HA. Hinted now that the target IP goes to HA when HA is used.
- Quite some people will use this with Home Assistant where the default UDP port is 9999. Also changed to that port in the sample. Also see issue #35.
- Added some comments around the read and write ports and their defaults. Makes it a bit easier to do the Home Assistant Nibe setup.