### PR TITLE
Handle new IPAddress structure

### DIFF
--- a/components/nibegw/NibeGwComponent.cpp
+++ b/components/nibegw/NibeGwComponent.cpp
@@ -30,7 +30,8 @@ void NibeGwComponent::callback_msg_received(const byte* const data, int len)
     ESP_LOGD(TAG, "UDP Packet with %d bytes to send", len);
     for (auto target = udp_targets_.begin(); target != udp_targets_.end(); target++)
     {
-        if (!udp_read_.writeTo(data, len, (uint32_t)std::get<0>(*target), std::get<1>(*target))) {
+        ip_addr_t address = (ip_addr_t)std::get<0>(*target);
+        if (!udp_read_.writeTo(data, len, &address, std::get<1>(*target))) {
             ESP_LOGW(TAG, "UDP Packet send failed to %s:%d",
                           std::get<0>(*target).str().c_str(),
                           std::get<1>(*target));
@@ -56,8 +57,8 @@ void NibeGwComponent::token_request_cache(AsyncUDPPacket& udp, byte address, byt
         return;
     }
 
-    network::IPAddress ip = (uint32_t)udp.remoteIP();
-    if (udp_source_ip_.size() && udp_source_ip_.count(ip) == 0) {
+    network::IPAddress ip = udp.remoteIP();
+    if (udp_source_ip_.size() && std::count(udp_source_ip_.begin(), udp_source_ip_.end(), ip) == 0) {
         ESP_LOGW(TAG, "UDP Packet wrong ip ignored %s", ip.str().c_str());
         return;
     }

--- a/components/nibegw/NibeGwComponent.h
+++ b/components/nibegw/NibeGwComponent.h
@@ -37,7 +37,7 @@ class NibeGwComponent: public esphome::Component, public esphome::uart::UARTDevi
     const int requests_queue_max = 3;
     int udp_read_port_  = 9999;
     int udp_write_port_ = 10000;
-    std::set<network::IPAddress> udp_source_ip_;
+    std::vector<network::IPAddress> udp_source_ip_;
     bool is_connected_ = false;
 
     std::vector<target_type> udp_targets_;
@@ -67,7 +67,7 @@ class NibeGwComponent: public esphome::Component, public esphome::uart::UARTDevi
     }
 
     void add_source_ip(const network::IPAddress& ip){
-        udp_source_ip_.insert(ip);
+        udp_source_ip_.push_back(ip);
     };
 
     void set_const_request(int address, int token, request_data_type request)


### PR DESCRIPTION
Correct handling of new Ip_address structure with changes in https://github.com/esphome/esphome/pull/5252

Since IPAddress is no longer sortable, we keep it as a vector instead. It's somewhat slower, but it will be a short list.

Fixes #40 