### PR TITLE
Make sure we have no double 5c for start code

### DIFF
--- a/components/nibegw/NibeGw.cpp
+++ b/components/nibegw/NibeGw.cpp
@@ -97,10 +97,12 @@ void NibeGw::loop()
         byte b = RS485->read();
         ESP_LOGVV(TAG, "%02X", b);
 
-        if (b == 0x5C)
+        buffer[0] = buffer[1];
+        buffer[1] = b;
+
+        if (buffer[0] == 0x5C && buffer[1] != 0x5C)
         {
-          buffer[0] = b;
-          index = 1;
+          index = 2;
           state = STATE_WAIT_DATA;
           ESP_LOGVV(TAG, "Frame start found");
         }


### PR DESCRIPTION
We must consume the double 5c, otherwise we just delay the 5c start reaction one byte.