### PR TITLE
Adding example for the Heltec HRI-485X

### DIFF
--- a/examples/heltec_hri-485x.yaml
+++ b/examples/heltec_hri-485x.yaml
@@ -1,6 +1,6 @@
 # Adapted from esphome example https://devices.esphome.io/devices/Heltec-HRI-485X
 # To install over stock firmware you must ground the internal USER pin to ground while powering up the device. 3.3v power must be applied to internal headers in order for it to be successful, it will not work with external power provided through the phoenix connectors
-# Tested initial install with Waveshare CH343G USB to TTL adapter
+# Tested initial install with Waveshare CH343G USB to TTL adapter on a Nibe F730
 
 esphome:
   name: "nibe-gw"

--- a/examples/heltec_hri-485x.yaml
+++ b/examples/heltec_hri-485x.yaml
@@ -1,0 +1,97 @@
+# Adapted from esphome example https://devices.esphome.io/devices/Heltec-HRI-485X
+# To install over stock firmware you must ground the internal USER pin to ground while powering up the device. 3.3v power must be applied to internal headers in order for it to be successful, it will not work with external power provided through the phoenix connectors
+# Tested initial install with Waveshare CH343G USB to TTL adapter
+
+esphome:
+  name: "nibe-gw"
+  friendly_name: Nibe GW
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+
+logger:
+  baud_rate: 0
+
+# Enable Home Assistant API
+api:  
+  on_client_connected:
+    switch.turn_on: HAOnlineLed
+  on_client_disconnected:
+    switch.turn_off: HAOnlineLed
+
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+status_led:
+  pin: GPIO3
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  fast_connect: true # Fast connect to connect to my hidden network
+  # It is recommended to disable powersave mode on wifi, to make sure the device does not miss UDP requests sent.
+  power_save_mode: none
+  # The device needs a static IP. Either do that here with the manual_ip node, or do it via another way (router)
+
+# Load nibe component
+external_components:
+  - source: github://elupus/esphome-nibe
+
+# Configure UART
+uart:
+  tx_pin: GPIO33
+  rx_pin: GPIO37
+  baud_rate: 9600
+
+# Set pins required for Heltec HRI-485X
+switch:
+  - platform: gpio
+    pin: GPIO16
+    id: ModbusOnOff # Enable MAX3485 chip
+
+  - platform: gpio
+    pin: GPIO2
+    id: HAOnlineLed # Show connection status to Home Assistant
+    inverted: true
+
+# Configure NibeGW
+nibegw:
+  udp:
+    # The target address(s) to send data to. May be a multicast address.
+    # When using Home Assistant: this is your Home Assistant IP.
+    target:
+      - ip: 192.168.255.2
+        port: 9999 #The Nibe Home Assistant integration listens to 9999 by default 
+
+    # List of source address to accept data from, may be empty for no filter
+    source:
+    #  - 192.168.255.254
+
+    # Optional port this device will listen to to receive read requests. Defaults to 9999
+    # read_port: 9999
+
+    # Optional port this device will listen to to receive write request. Defaults to 10000
+    # write_port: 10000
+
+  acknowledge:
+    - MODBUS40
+
+  # Constant replies to certain requests cabe made
+  constants:
+    - address: MODBUS40
+      token: ACCESSORY
+      data: [
+            0x0A, # MODBUS version low
+            0x00, # MODBUS version high
+            0x01, # MODBUS address?
+      ]
+
+# Some helper functions to restart ESPHome from HA
+button:
+- platform: restart
+  name: Nibegw Restart
+- platform: safe_mode
+  name: Nibegw Safe Mode Boot

--- a/examples/heltec_hri-485x.yaml
+++ b/examples/heltec_hri-485x.yaml
@@ -11,9 +11,6 @@ esp32:
   framework:
     type: arduino
 
-logger:
-  baud_rate: 0
-
 # Enable Home Assistant API
 api:  
   on_client_connected:
@@ -25,8 +22,8 @@ ota:
   - platform: esphome
     password: !secret ota_password
 
-status_led:
-  pin: GPIO3
+logger:
+  baud_rate: 0
 
 wifi:
   ssid: !secret wifi_ssid
@@ -57,18 +54,21 @@ switch:
     id: HAOnlineLed # Show connection status to Home Assistant
     inverted: true
 
+status_led:
+  pin: GPIO3
+
 # Configure NibeGW
 nibegw:
   udp:
     # The target address(s) to send data to. May be a multicast address.
     # When using Home Assistant: this is your Home Assistant IP.
     target:
-      - ip: 192.168.255.2
+      - ip: 192.168.255.254
         port: 9999 #The Nibe Home Assistant integration listens to 9999 by default 
 
     # List of source address to accept data from, may be empty for no filter
     source:
-    #  - 192.168.255.254
+      - 192.168.255.254
 
     # Optional port this device will listen to to receive read requests. Defaults to 9999
     # read_port: 9999


### PR DESCRIPTION
Recently acquired a Heltec HRI-485X after burning out my LilyGo T-CAN485. Was looking for something that came within a case to avoid any future shorting out!

It was quite tricky figuring out what I had to do to get esphome installed over the stock firmware but eventually figured it out. You need to short the USER pin to ground while applying power to the unit through the 3.3V pin inside. It will not work if you supply power to the external phoenix connector.

I have only tested this on a Nibe F730 and over Wi-Fi. I am sure the example can be adapted to work over ethernet but I have yet to try that out. I will submit a future pull request after I can confirm it is stable on Wi-Fi.

The actual config has just been adapted from the esphome docs https://devices.esphome.io/devices/Heltec-HRI-485X