### PR TITLE
refactor: modernize NibeGwComponent with deque, multi-listener, priority queue

### DIFF
--- a/components/nibegw/NibeGw.cpp
+++ b/components/nibegw/NibeGw.cpp
@@ -23,11 +23,9 @@
 using namespace esphome;
 
 NibeGw::NibeGw(esphome::uart::UARTDevice *serial, esphome::GPIOPin *RS485DirectionPin) {
-  state = STATE_WAIT_START;
-  connectionState = false;
   RS485 = serial;
   directionPin = RS485DirectionPin;
-  setCallback(NULL, NULL);
+  setCallback(nullptr, nullptr);
 }
 
 void NibeGw::connect() {
@@ -226,9 +224,9 @@ void NibeGw::loop() {
   }
 }
 
-uint8_t NibeGw::calculateChecksum(const uint8_t *const data, uint8_t len) {
+uint8_t NibeGw::calculateChecksum(const uint8_t *data, size_t len) {
   uint8_t checksum = 0;
-  for (uint8_t i = 0; i < len; i++) {
+  for (size_t i = 0; i < len; i++) {
     checksum ^= data[i];
   }
 
@@ -255,7 +253,7 @@ void NibeGw::sendEnd() {
   }
 }
 
-void NibeGw::sendData(const uint8_t *const data, uint8_t len) {
+void NibeGw::sendData(const uint8_t *data, uint8_t len) {
   sendBegin();
   RS485->write_array(data, len);
   sendEnd();

--- a/components/nibegw/NibeGw.h
+++ b/components/nibegw/NibeGw.h
@@ -54,11 +54,14 @@ enum eState {
 };
 
 enum eTokenType {
-  READ_TOKEN = 0x69,
-  WRITE_TOKEN = 0x6B,
   RMU_WRITE_TOKEN = 0x60,
   RMU_DATA_MSG = 0x62,
   RMU_DATA_TOKEN = 0x63,
+  MODBUS_DATA_MSG = 0x68,
+  READ_TOKEN = 0x69,
+  MODBUS_READ_RESP = 0x6A,
+  WRITE_TOKEN = 0x6B,
+  MODBUS_WRITE_RESP = 0x6C,
   ACCESSORY_TOKEN = 0xEE,
 };
 
@@ -94,18 +97,18 @@ typedef std::function<int(uint16_t address, uint8_t command, uint8_t *data)> cal
 
 class NibeGw {
  private:
-  eState state;
-  bool connectionState;
-  esphome::GPIOPin *directionPin;
-  uint8_t buffer[MAX_DATA_LEN * 2];
-  size_t index;
-  size_t indexSlave;
-  esphome::uart::UARTDevice *RS485;
+  eState state{STATE_WAIT_START};
+  bool connectionState{false};
+  esphome::GPIOPin *directionPin{nullptr};
+  uint8_t buffer[MAX_DATA_LEN * 2]{};  // zero-initialize
+  size_t index{0};
+  size_t indexSlave{0};
+  esphome::uart::UARTDevice *RS485{nullptr};
   callback_msg_received_type callback_msg_received;
   callback_msg_token_received_type callback_msg_token_received;
   std::set<uint16_t> addressAcknowledge;
 
-  uint8_t calculateChecksum(const uint8_t *data, uint8_t len);
+  uint8_t calculateChecksum(const uint8_t *data, size_t len);
   void sendData(const uint8_t *data, uint8_t len);
   void sendBegin();
   void sendEnd();
@@ -119,7 +122,7 @@ class NibeGw {
   void stateCompleteAck();
   void stateComplete(uint8_t data);
 
-  const char *TAG = "nibeGW";
+  static constexpr const char *TAG = "nibegw";
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
 #define DEBUG_BUFFER_LEN 300
   char debug_buf[DEBUG_BUFFER_LEN];

--- a/components/nibegw/NibeGwComponent.cpp
+++ b/components/nibegw/NibeGwComponent.cpp
@@ -29,9 +29,12 @@ static request_data_type dedup(const uint8_t *data, int len, uint8_t val) {
 void NibeGwComponent::callback_msg_received(const uint8_t *data, int len) {
   {
     request_key_type key{data[2] | (data[1] << 8), static_cast<uint8_t>(data[3])};
-    const auto &it = message_listener_.find(key);
-    if (it != message_listener_.end()) {
-      it->second(dedup(data, len, STARTBYTE_MASTER));
+    const auto &it = message_listeners_.find(key);
+    if (it != message_listeners_.end()) {
+      auto deduped = dedup(data, len, STARTBYTE_MASTER);
+      for (auto &listener : it->second) {
+        listener(deduped);
+      }
     }
   }
 
@@ -42,7 +45,6 @@ void NibeGwComponent::callback_msg_received(const uint8_t *data, int len) {
   /* always sending standard data from modbus read token */
   auto &udp_read_ = requests_sockets_[request_key_type(MODBUS40, READ_TOKEN)].socket;
   if (!udp_read_) {
-    ESP_LOGW(TAG, "UDP read socket not available");
     return;
   }
 
@@ -69,7 +71,7 @@ void NibeGwComponent::recv_local_socket(socket_ptr_type &fd, int address, int to
   request.resize(n);
 
   if (udp_sources_.size() &&
-      none_of(udp_sources_.begin(), udp_sources_.end(), [&](auto &source) { return from.matches(source); })) {
+      std::none_of(udp_sources_.begin(), udp_sources_.end(), [&](auto &source) { return from.matches(source); })) {
     ESP_LOGW(TAG, "UDP Packet wrong ip ignored %s", from.str().c_str());
     return;
   }
@@ -104,7 +106,7 @@ int NibeGwComponent::callback_msg_token_received(uint16_t address, uint8_t comma
       auto &queue = it->second;
       if (!queue.empty()) {
         auto len = copy_request(queue.front(), data);
-        queue.pop();
+        queue.pop_front();
         ESP_LOGD(TAG, "Response to address: 0x%x token: 0x%x bytes: %d", std::get<0>(key), std::get<1>(key), len);
         return len;
       }
@@ -139,6 +141,9 @@ void NibeGwComponent::dump_config() {
   for (auto const &x : requests_sockets_) {
     ESP_LOGCONFIG(TAG, " Handler %x:%x Port: %d", std::get<0>(x.first), std::get<1>(x.first), x.second.port);
   }
+  for (auto const &x : message_listeners_) {
+    ESP_LOGCONFIG(TAG, " Listeners %x:%x Count: %zu", std::get<0>(x.first), std::get<1>(x.first), x.second.size());
+  }
 }
 
 socket_ptr_type NibeGwComponent::bind_local_socket(int port) {
@@ -147,7 +152,6 @@ socket_ptr_type NibeGwComponent::bind_local_socket(int port) {
     // Set non-blocking
     fd->setblocking(false);
 
-    // Bind to write port
     socket_address address(port);
 
     if (fd->bind((sockaddr *) &address.storage, address.len) < 0) {
@@ -189,7 +193,6 @@ void NibeGwComponent::run_request_socket(const request_key_type &key, request_so
 
 void NibeGwComponent::loop() {
   // Handle network connection state
-
   if (network::is_connected()) {
     if (!is_connected_) {
       ESP_LOGI(TAG, "Connecting network ports.");
@@ -210,7 +213,7 @@ void NibeGwComponent::loop() {
   }
 
   // Check for timeouts on targets
-  std::erase_if(udp_targets_, [&](const auto &item) { return now - item.second > target_timeout_ms_; });
+  std::erase_if(udp_targets_, [&](const auto &item) { return now - item.second > TARGET_TIMEOUT_MS; });
 
   // Poll sockets for incoming packets
   for (auto &[key, data] : requests_sockets_) {

--- a/components/nibegw/NibeGwComponent.h
+++ b/components/nibegw/NibeGwComponent.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <set>
-#include <queue>
+#include <deque>
 #include <vector>
 #include <cstddef>
 #include <cstdint>
@@ -23,17 +23,15 @@
 namespace esphome {
 namespace nibegw {
 
-using namespace std;
-
-typedef std::tuple<uint16_t, uint8_t> request_key_type;
-typedef std::vector<uint8_t> request_data_type;
-typedef std::function<request_data_type(void)> request_provider_type;
-typedef std::function<void(const request_data_type &)> message_listener_type;
+using request_key_type = std::tuple<uint16_t, uint8_t>;
+using request_data_type = std::vector<uint8_t>;
+using request_provider_type = std::function<request_data_type(void)>;
+using message_listener_type = std::function<void(const request_data_type &)>;
 
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 3, 0)
-typedef std::unique_ptr<socket::ListenSocket> socket_ptr_type;
+using socket_ptr_type = std::unique_ptr<socket::ListenSocket>;
 #else
-typedef std::unique_ptr<socket::Socket> socket_ptr_type;
+using socket_ptr_type = std::unique_ptr<socket::Socket>;
 #endif
 
 struct request_socket_type {
@@ -45,25 +43,24 @@ class NibeGwComponent : public esphome::Component, public esphome::uart::UARTDev
   float get_setup_priority() const override {
     return setup_priority::PROCESSOR;
   }
-  const char *TAG = "nibegw";
-  const int requests_queue_max = 3;
-  const uint32_t target_timeout_ms_ = 120000;
+  static constexpr const char *TAG = "nibegw";
+  static constexpr size_t REQUESTS_QUEUE_MAX = 3;
+  static constexpr uint32_t TARGET_TIMEOUT_MS = 120000;
   bool is_connected_ = false;
 
   std::vector<socket_address> udp_sources_;
   std::vector<socket_address> udp_targets_static_;
   std::map<socket_address, uint32_t> udp_targets_;
-  std::map<request_key_type, std::queue<request_data_type>> requests_;
+  std::map<request_key_type, std::deque<request_data_type>> requests_;
   std::map<request_key_type, request_provider_type> requests_provider_;
   std::map<request_key_type, request_socket_type> requests_sockets_;
-  std::map<request_key_type, message_listener_type> message_listener_;
+  std::map<request_key_type, std::vector<message_listener_type>> message_listeners_;
   HighFrequencyLoopRequester high_freq_;
 
   NibeGw *gw_;
 
   void callback_msg_received(const uint8_t *data, int len);
   int callback_msg_token_received(uint16_t address, uint8_t command, uint8_t *data);
-  void callback_debug(uint8_t verbose, char *data);
 
   void run_request_socket(const request_key_type &key, request_socket_type &data);
   void recv_local_socket(socket_ptr_type &fd, int address, int token);
@@ -77,7 +74,7 @@ class NibeGwComponent : public esphome::Component, public esphome::uart::UARTDev
 
   void add_source_ip(const network::IPAddress &ip) {
     udp_sources_.push_back(socket_address(ip, 0));
-  };
+  }
 
   void add_socket_request(int address, int token, int port) {
     auto &handler = requests_sockets_[request_key_type(address, token)];
@@ -93,16 +90,35 @@ class NibeGwComponent : public esphome::Component, public esphome::uart::UARTDev
   }
 
   void add_listener(int address, int token, message_listener_type listener) {
-    message_listener_[request_key_type(address, token)] = listener;
+    message_listeners_[request_key_type(address, token)].push_back(std::move(listener));
   }
 
   void add_queued_request(int address, int token, request_data_type request) {
     auto &queue = requests_[request_key_type(address, token)];
-    if (queue.size() >= requests_queue_max) {
-      queue.pop();
+    if (queue.size() >= REQUESTS_QUEUE_MAX) {
+      ESP_LOGV(TAG, "Request queue full for 0x%x:0x%x, dropping oldest", address, token);
+      queue.pop_front();
     }
-    queue.push(std::move(request));
+    queue.push_back(std::move(request));
   }
+
+  // Priority request: inserted at front of queue (for write-verify reads)
+  void add_priority_request(int address, int token, request_data_type request) {
+    auto &queue = requests_[request_key_type(address, token)];
+    if (queue.size() >= REQUESTS_QUEUE_MAX) {
+      ESP_LOGV(TAG, "Request queue full for 0x%x:0x%x, dropping oldest", address, token);
+      queue.pop_back();  // drop newest (least important) to make room
+    }
+    queue.push_front(std::move(request));
+  }
+
+  const std::deque<request_data_type> &get_request_queue(int address, int token) const {
+    static const std::deque<request_data_type> empty;
+    auto it = requests_.find(request_key_type(address, token));
+    return (it != requests_.end()) ? it->second : empty;
+  }
+
+  static constexpr size_t get_queue_capacity() { return REQUESTS_QUEUE_MAX; }
 
   void add_acknowledge(int address) {
     gw_->setAcknowledge(address, true);


### PR DESCRIPTION
## Summary

Modernize NibeGwComponent to support multiple listeners per message type, priority request queuing, and cleaner C++ patterns. These improvements are needed by the sensor polling feature (follow-up PR) but also benefit the existing codebase.

**Depends on:** #157 (NibeGw protocol fixes)

### Changes

**Multi-listener support:**
- `message_listener_` changed from single callback to `vector<callback>` per key
- `add_listener()` now appends instead of replacing - multiple components can listen on the same (address, token) pair without conflict
- Deduped data is computed once and passed to all listeners

**Priority queue:**
- `std::queue` → `std::deque` for request queues, enabling front-insertion
- New `add_priority_request()` method inserts at front of queue for time-sensitive reads (e.g., write-verify reads that need to jump ahead of regular polling)
- Existing `add_queued_request()` behavior unchanged (back of queue)

**Queue visibility:**
- New `get_request_queue()` returns const reference to queue for size checking
- New `get_queue_capacity()` exposes max queue size
- Enables callers to check available queue space before batching requests

**Modern C++:**
- `using` aliases replace `typedef`
- `static constexpr` replaces `const` member variables
- Removed `using namespace std` (namespace pollution)
- Removed unused `callback_debug` declaration
- Queue overflow logged at VERBOSE level
- Registered listener counts shown in `dump_config()`

**UDP log cleanup:**
- Removed noisy "UDP read socket not available" warning that spammed logs when UDP was disabled (sensors-only mode)

### Why these changes?

The sensor polling feature (next PR) needs:
1. **Multi-listener** - to listen on MODBUS_DATA_MSG (0x68) and MODBUS_READ_RESP (0x6A) without conflicting with other components
2. **Priority queue** - for write-verify reads that need fast response
3. **Queue visibility** - for batch polling to respect queue capacity

### Testing
- Compiled and tested on ESP32-C3 with DM9051 Ethernet + Nibe F1155
- Existing UDP gateway functionality verified
- Climate component verified (uses add_listener, now multi-listener compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)