### PR TITLE
feat: add direct MQTT sensor polling with configurable poll groups

### DIFF
--- a/components/nibegw/NibeGwCoilNumber.cpp
+++ b/components/nibegw/NibeGwCoilNumber.cpp
@@ -1,0 +1,132 @@
+#include "NibeGwCoilNumber.h"
+#include "NibeGwCoilPoller.h"
+#include "NibeGwComponent.h"
+#include "NibeGw.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace nibegw {
+
+static const char *TAG = "nibegw.number";
+
+void NibeGwCoilNumber::setup() {
+  if (poller_ == nullptr || gw_ == nullptr) {
+    ESP_LOGE(TAG, "Poller or gateway not set for number at address %u", address_);
+    this->mark_failed();
+    return;
+  }
+  // Register as listener to receive current value from pump (via read polling)
+  poller_->register_coil(address_, static_cast<CoilSize>(coil_size_), factor_, poll_group_,
+                         [this](float value) { this->publish_state(value); });
+
+  // Flag to read initial value on first loop iteration
+  needs_initial_read_ = true;
+}
+
+void NibeGwCoilNumber::loop() {
+  // Queue initial read once gateway is connected
+  if (needs_initial_read_ && millis() > 5000) {
+    needs_initial_read_ = false;
+    ESP_LOGD(TAG, "Queuing initial read for coil %u", address_);
+    queue_read_request();
+  }
+
+  // Check for write timeout
+  if (write_pending_ && (millis() - write_sent_at_ > WRITE_TIMEOUT_MS)) {
+    ESP_LOGW(TAG, "Write timeout for coil %u", address_);
+    write_pending_ = false;
+  }
+}
+
+void NibeGwCoilNumber::dump_config() {
+  LOG_NUMBER("", "NibeGW Coil Number", this);
+  ESP_LOGCONFIG(TAG, "  Address: %u", address_);
+  ESP_LOGCONFIG(TAG, "  Size: %u", coil_size_);
+  ESP_LOGCONFIG(TAG, "  Factor: %u", factor_);
+}
+
+void NibeGwCoilNumber::control(float value) {
+  // Encode the value as raw integer
+  int32_t raw;
+  if (factor_ > 1) {
+    raw = (int32_t) roundf(value * (float) factor_);
+  } else {
+    raw = (int32_t) roundf(value);
+  }
+
+  // Build payload: address (2 bytes LE) + value (ALWAYS 4 bytes LE per Nibe protocol)
+  // Format: C0 6B 06 [addr_lo addr_hi val0 val1 val2 val3] checksum
+  std::vector<uint8_t> payload;
+  payload.push_back(address_ & 0xFF);
+  payload.push_back((address_ >> 8) & 0xFF);
+  payload.push_back(raw & 0xFF);
+  payload.push_back((raw >> 8) & 0xFF);
+  payload.push_back((raw >> 16) & 0xFF);
+  payload.push_back((raw >> 24) & 0xFF);
+
+  // Build the packet: start, cmd, len, payload, checksum
+  request_data_type packet;
+  packet.push_back(STARTBYTE_SLAVE);
+  packet.push_back(WRITE_TOKEN);
+  packet.push_back(payload.size());  // always 6 (2 addr + 4 value)
+  for (auto b : payload) {
+    packet.push_back(b);
+  }
+
+  uint8_t checksum = 0;
+  for (auto b : packet) {
+    checksum ^= b;
+  }
+  if (checksum == 0x5C) {
+    checksum = 0xC5;
+  }
+  packet.push_back(checksum);
+
+  write_pending_ = true;
+  write_requested_value_ = value;
+  write_sent_at_ = millis();
+
+  ESP_LOGI(TAG, "Writing coil %u = %.2f (raw: %d)", address_, value, (int) raw);
+  gw_->add_queued_request(MODBUS40, WRITE_TOKEN, std::move(packet));
+}
+
+void NibeGwCoilNumber::on_write_response(bool success) {
+  if (!write_pending_) {
+    return;
+  }
+  write_pending_ = false;
+
+  if (success) {
+    ESP_LOGI(TAG, "Write confirmed for coil %u = %.2f", address_, write_requested_value_);
+    // Queue a read request to verify the value from the pump
+    queue_read_request();
+  } else {
+    ESP_LOGW(TAG, "Write DENIED by pump for coil %u", address_);
+  }
+}
+
+void NibeGwCoilNumber::queue_read_request() {
+  // Build a read request to verify the written value
+  // Format: C0 69 02 [addr_lo addr_hi] checksum
+  request_data_type packet;
+  packet.push_back(STARTBYTE_SLAVE);
+  packet.push_back(READ_TOKEN);
+  packet.push_back(0x02);
+  packet.push_back(address_ & 0xFF);
+  packet.push_back((address_ >> 8) & 0xFF);
+
+  uint8_t checksum = 0;
+  for (auto b : packet) {
+    checksum ^= b;
+  }
+  if (checksum == 0x5C) {
+    checksum = 0xC5;
+  }
+  packet.push_back(checksum);
+
+  // Use priority request so verify-reads jump ahead of regular polling
+  gw_->add_priority_request(MODBUS40, READ_TOKEN, std::move(packet));
+}
+
+}  // namespace nibegw
+}  // namespace esphome

--- a/components/nibegw/NibeGwCoilNumber.h
+++ b/components/nibegw/NibeGwCoilNumber.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <string>
+
+#include "esphome/core/component.h"
+#include "esphome/components/number/number.h"
+
+namespace esphome {
+namespace nibegw {
+
+class NibeGwComponent;
+class NibeGwCoilPoller;
+
+class NibeGwCoilNumber : public number::Number, public Component {
+ public:
+  void set_gw(NibeGwComponent *gw) { gw_ = gw; }
+  void set_poller(NibeGwCoilPoller *poller) { poller_ = poller; }
+  void set_address(uint16_t address) { address_ = address; }
+  void set_coil_size(uint8_t size) { coil_size_ = size; }
+  void set_factor(uint16_t factor) { factor_ = factor; }
+  void set_poll_group(const std::string &group) { poll_group_ = group; }
+
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  // Called by poller when write response (0x6C) arrives
+  void on_write_response(bool success);
+
+ protected:
+  void control(float value) override;
+  void queue_read_request();
+
+  NibeGwComponent *gw_{nullptr};
+  NibeGwCoilPoller *poller_{nullptr};
+  uint16_t address_{0};
+  uint8_t coil_size_{0};
+  uint16_t factor_{1};
+  std::string poll_group_{"default"};
+
+  // Initial read flag
+  bool needs_initial_read_{false};
+
+  // Write state tracking
+  bool write_pending_{false};
+  float write_requested_value_{0};
+  uint32_t write_sent_at_{0};
+  static const uint32_t WRITE_TIMEOUT_MS = 10000;
+};
+
+}  // namespace nibegw
+}  // namespace esphome

--- a/components/nibegw/NibeGwCoilPoller.cpp
+++ b/components/nibegw/NibeGwCoilPoller.cpp
@@ -1,0 +1,308 @@
+#include "NibeGwCoilPoller.h"
+#include "NibeGw.h"
+#include "esphome/core/log.h"
+
+#ifdef USE_MQTT
+#include "esphome/components/mqtt/mqtt_client.h"
+#endif
+
+namespace esphome {
+namespace nibegw {
+
+void NibeGwCoilPoller::add_poll_group(const std::string &id, uint32_t interval_ms) {
+  poll_groups_.push_back({id, interval_ms, {}, 0, 0});
+  poll_group_index_[id] = poll_groups_.size() - 1;
+}
+
+void NibeGwCoilPoller::register_coil(uint16_t address, CoilSize size, uint16_t factor,
+                                     const std::string &poll_group,
+                                     std::function<void(float)> callback) {
+  size_t coil_idx = coils_.size();
+  coils_.push_back({address, size, factor, std::move(callback)});
+  coil_index_[address] = coil_idx;
+
+  auto it = poll_group_index_.find(poll_group);
+  if (it == poll_group_index_.end()) {
+    add_poll_group(poll_group, default_poll_interval_ms_);
+    it = poll_group_index_.find(poll_group);
+  }
+  poll_groups_[it->second].coil_indices.push_back(coil_idx);
+}
+
+void NibeGwCoilPoller::setup() {
+  if (buffer_mode_ == BUFFER_MODE_HISTORY && buffer_size_bytes_ > 0) {
+    size_t capacity = buffer_size_bytes_ / sizeof(BufferEntry);
+    if (capacity > 0) {
+      history_buffer_.resize(capacity);
+    }
+  }
+
+  // Listen on MODBUS_DATA_MSG (0x68) - pump's periodic broadcast with 2-byte values
+  gw_->add_listener(MODBUS40, MODBUS_DATA_MSG,
+                     [this](const request_data_type &data) { this->on_data_msg_received(data); });
+
+  // Listen on MODBUS_READ_RESP (0x6A) - response to our read requests with 4-byte values
+  gw_->add_listener(MODBUS40, MODBUS_READ_RESP,
+                     [this](const request_data_type &data) { this->on_read_response_received(data); });
+
+  ESP_LOGI(TAG, "Coil poller set up with %zu coils in %zu poll groups",
+           coils_.size(), poll_groups_.size());
+}
+
+void NibeGwCoilPoller::loop() {
+  uint32_t now = millis();
+
+  bool connected = is_mqtt_connected();
+  if (connected && !was_connected_) {
+    ESP_LOGI(TAG, "MQTT reconnected, flushing buffer");
+    flush_buffer();
+  }
+  was_connected_ = connected;
+
+  // Queue coil read requests in batches per group. Each group gets up to
+  // BATCH_SIZE requests per tick, but only if there's space in the shared
+  // queue. This prevents fast groups from starving slower groups.
+  auto &queue = gw_->get_request_queue(MODBUS40, READ_TOKEN);
+  for (auto &group : poll_groups_) {
+    if (group.coil_indices.empty()) {
+      continue;
+    }
+
+    if (now - group.last_poll >= group.interval_ms) {
+      group.last_poll = now;
+      size_t available = (queue.size() < QUEUE_CAPACITY) ? QUEUE_CAPACITY - queue.size() : 0;
+      size_t batch = std::min({group.coil_indices.size(), (size_t) BATCH_SIZE, available});
+      for (size_t i = 0; i < batch; i++) {
+        auto request = build_read_request(group);
+        if (!request.empty()) {
+          gw_->add_queued_request(MODBUS40, READ_TOKEN, std::move(request));
+        }
+      }
+    }
+  }
+}
+
+void NibeGwCoilPoller::dump_config() {
+  ESP_LOGCONFIG(TAG, "NibeGW Coil Poller:");
+  ESP_LOGCONFIG(TAG, "  Buffer mode: %s",
+                buffer_mode_ == BUFFER_MODE_OFF           ? "off"
+                : buffer_mode_ == BUFFER_MODE_LATEST_ONLY ? "latest_only"
+                                                          : "history");
+  if (buffer_mode_ == BUFFER_MODE_HISTORY) {
+    ESP_LOGCONFIG(TAG, "  Buffer size: %zu bytes (%zu entries)", buffer_size_bytes_,
+                  history_buffer_.size());
+  }
+  ESP_LOGCONFIG(TAG, "  Total coils: %zu", coils_.size());
+  for (auto &group : poll_groups_) {
+    ESP_LOGCONFIG(TAG, "  Poll group '%s': interval %u ms, %zu coils",
+                  group.id.c_str(), group.interval_ms, group.coil_indices.size());
+  }
+}
+
+request_data_type NibeGwCoilPoller::build_read_request(PollGroup &group) {
+  if (group.coil_indices.empty()) {
+    return {};
+  }
+
+  // Send ONE coil address per request (Nibe protocol: MODBUS_READ_REQ = C0 69 02 addr_lo addr_hi checksum)
+  size_t coil_idx = group.coil_indices[group.poll_offset];
+  group.poll_offset = (group.poll_offset + 1) % group.coil_indices.size();
+
+  uint16_t addr = coils_[coil_idx].address;
+  ESP_LOGD(TAG, "Polling coil %u (group '%s')", addr, group.id.c_str());
+
+  request_data_type packet;
+  packet.push_back(STARTBYTE_SLAVE);
+  packet.push_back(READ_TOKEN);
+  packet.push_back(0x02);  // length: 2 bytes (one address)
+  packet.push_back(addr & 0xFF);
+  packet.push_back((addr >> 8) & 0xFF);
+
+  uint8_t checksum = 0;
+  for (auto b : packet) {
+    checksum ^= b;
+  }
+  if (checksum == 0x5C) {
+    checksum = 0xC5;
+  }
+  packet.push_back(checksum);
+
+  return packet;
+}
+
+void NibeGwCoilPoller::on_data_msg_received(const request_data_type &data) {
+  // MODBUS_DATA_MSG (0x68): pump broadcast with 4-byte entries [addr_lo addr_hi val_lo val_hi]
+  ESP_LOGV(TAG, "Data broadcast received: %zu bytes", data.size());
+  size_t offset = 0;
+  while (offset + 4 <= data.size()) {
+    uint16_t address = data[offset] | (data[offset + 1] << 8);
+    offset += 2;
+
+    if (address == 0xFFFF) {
+      offset += 2;  // skip padding
+      continue;
+    }
+
+    auto it = coil_index_.find(address);
+    if (it == coil_index_.end()) {
+      offset += 2;  // skip 2-byte value for unknown coil
+      continue;
+    }
+
+    auto &coil = coils_[it->second];
+
+    // Broadcast values are always 2 bytes
+    if (offset + 2 > data.size()) {
+      break;
+    }
+
+    float value = decode_coil_value(&data[offset], coil.size, coil.factor);
+    offset += 2;
+
+    ESP_LOGD(TAG, "Broadcast coil %u = %.2f", address, value);
+    coil.callback(value);
+    buffer_value(address, value);
+  }
+}
+
+void NibeGwCoilPoller::on_read_response_received(const request_data_type &data) {
+  // MODBUS_READ_RESP (0x6A): response to our read request
+  // Format: [addr_lo addr_hi val_b0 val_b1 val_b2 val_b3] = 6 bytes
+  ESP_LOGV(TAG, "Read response received: %zu bytes", data.size());
+  if (data.size() < 6) {
+    ESP_LOGW(TAG, "Read response too short: %zu bytes", data.size());
+    return;
+  }
+
+  uint16_t address = data[0] | (data[1] << 8);
+
+  auto it = coil_index_.find(address);
+  if (it == coil_index_.end()) {
+    ESP_LOGD(TAG, "Read response for unknown coil %u", address);
+    return;
+  }
+
+  auto &coil = coils_[it->second];
+
+  // Read response always has 4 value bytes - decode based on coil size
+  float value = decode_coil_value(&data[2], coil.size, coil.factor);
+
+  ESP_LOGD(TAG, "Read response coil %u = %.2f", address, value);
+  coil.callback(value);
+  buffer_value(address, value);
+}
+
+float NibeGwCoilPoller::decode_coil_value(const uint8_t *data, CoilSize size, uint16_t factor) {
+  float raw;
+  switch (size) {
+    case COIL_SIZE_U8:
+      raw = (float) data[0];
+      break;
+    case COIL_SIZE_S8:
+      raw = (float) (int8_t) data[0];
+      break;
+    case COIL_SIZE_U16:
+      raw = (float) (uint16_t)(data[0] | (data[1] << 8));
+      break;
+    case COIL_SIZE_S16: {
+      int16_t val = (int16_t)(data[0] | (data[1] << 8));
+      if (val == -32768) return NAN;  // 0x8000 = Nibe "no sensor" for s16
+      raw = (float) val;
+      break;
+    }
+    case COIL_SIZE_U32:
+      raw = (float) ((uint32_t) data[0] | ((uint32_t) data[1] << 8) | ((uint32_t) data[2] << 16) |
+                      ((uint32_t) data[3] << 24));
+      break;
+    case COIL_SIZE_S32:
+      raw = (float) (int32_t)((uint32_t) data[0] | ((uint32_t) data[1] << 8) | ((uint32_t) data[2] << 16) |
+                               ((uint32_t) data[3] << 24));
+      break;
+    default:
+      return NAN;
+  }
+  if (factor > 1) {
+    return raw / (float) factor;
+  }
+  return raw;
+}
+
+uint8_t NibeGwCoilPoller::coil_data_bytes(CoilSize size) {
+  switch (size) {
+    case COIL_SIZE_U8:
+    case COIL_SIZE_S8:
+      return 2;
+    case COIL_SIZE_U16:
+    case COIL_SIZE_S16:
+      return 2;
+    case COIL_SIZE_U32:
+    case COIL_SIZE_S32:
+      return 4;
+    default:
+      return 2;
+  }
+}
+
+void NibeGwCoilPoller::buffer_value(uint16_t address, float value) {
+  if (buffer_mode_ == BUFFER_MODE_OFF) {
+    return;
+  }
+
+  if (buffer_mode_ == BUFFER_MODE_LATEST_ONLY) {
+    latest_buffer_[address] = value;
+    return;
+  }
+
+  if (history_buffer_.empty()) {
+    return;
+  }
+
+  size_t capacity = history_buffer_.size();
+  size_t write_idx = (history_head_ + history_count_) % capacity;
+  history_buffer_[write_idx] = {millis(), address, value};
+  if (history_count_ < capacity) {
+    history_count_++;
+  } else {
+    history_head_ = (history_head_ + 1) % capacity;
+  }
+}
+
+void NibeGwCoilPoller::flush_buffer() {
+  if (buffer_mode_ == BUFFER_MODE_LATEST_ONLY) {
+    for (auto &[address, value] : latest_buffer_) {
+      auto it = coil_index_.find(address);
+      if (it != coil_index_.end()) {
+        coils_[it->second].callback(value);
+      }
+    }
+    latest_buffer_.clear();
+    return;
+  }
+
+  if (buffer_mode_ == BUFFER_MODE_HISTORY) {
+    ESP_LOGI(TAG, "Flushing %zu buffered entries", history_count_);
+    for (size_t i = 0; i < history_count_; i++) {
+      size_t idx = (history_head_ + i) % history_buffer_.size();
+      auto &entry = history_buffer_[idx];
+      auto it = coil_index_.find(entry.address);
+      if (it != coil_index_.end()) {
+        coils_[it->second].callback(entry.value);
+      }
+    }
+    history_count_ = 0;
+    history_head_ = 0;
+    return;
+  }
+}
+
+bool NibeGwCoilPoller::is_mqtt_connected() {
+#ifdef USE_MQTT
+  if (mqtt::global_mqtt_client != nullptr) {
+    return mqtt::global_mqtt_client->is_connected();
+  }
+#endif
+  return true;
+}
+
+}  // namespace nibegw
+}  // namespace esphome

--- a/components/nibegw/NibeGwCoilPoller.h
+++ b/components/nibegw/NibeGwCoilPoller.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "esphome/core/component.h"
+#include "NibeGwComponent.h"
+
+namespace esphome {
+namespace nibegw {
+
+enum CoilSize : uint8_t {
+  COIL_SIZE_U8 = 0,
+  COIL_SIZE_U16 = 1,
+  COIL_SIZE_S16 = 2,
+  COIL_SIZE_U32 = 3,
+  COIL_SIZE_S32 = 4,
+  COIL_SIZE_S8 = 5,
+};
+
+enum BufferMode : uint8_t {
+  BUFFER_MODE_OFF = 0,
+  BUFFER_MODE_LATEST_ONLY = 1,
+  BUFFER_MODE_HISTORY = 2,
+};
+
+struct CoilRegistration {
+  uint16_t address;
+  CoilSize size;
+  uint16_t factor;
+  std::function<void(float)> callback;
+};
+
+struct BufferEntry {
+  uint32_t timestamp;
+  uint16_t address;
+  float value;
+};
+
+struct PollGroup {
+  std::string id;
+  uint32_t interval_ms;
+  std::vector<size_t> coil_indices;
+  size_t poll_offset{0};
+  uint32_t last_poll{0};
+};
+
+class NibeGwCoilPoller : public Component {
+ public:
+  void set_gw(NibeGwComponent *gw) { gw_ = gw; }
+  void set_buffer_size(size_t bytes) { buffer_size_bytes_ = bytes; }
+  void set_buffer_mode(uint8_t mode) { buffer_mode_ = static_cast<BufferMode>(mode); }
+  void set_poll_interval(uint32_t ms) { default_poll_interval_ms_ = ms; }
+
+  void add_poll_group(const std::string &id, uint32_t interval_ms);
+
+  void register_coil(uint16_t address, CoilSize size, uint16_t factor,
+                     const std::string &poll_group, std::function<void(float)> callback);
+
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  float get_setup_priority() const override {
+    return setup_priority::DATA;
+  }
+
+ protected:
+  static float decode_coil_value(const uint8_t *data, CoilSize size, uint16_t factor);
+  static uint8_t coil_data_bytes(CoilSize size);
+  request_data_type build_read_request(PollGroup &group);
+  void on_data_msg_received(const request_data_type &data);
+  void on_read_response_received(const request_data_type &data);
+  void buffer_value(uint16_t address, float value);
+  void flush_buffer();
+  bool is_mqtt_connected();
+
+  static constexpr size_t BATCH_SIZE = 3;           // max coils per group per tick
+  static constexpr size_t QUEUE_CAPACITY = NibeGwComponent::get_queue_capacity();
+
+  NibeGwComponent *gw_{nullptr};
+  uint32_t default_poll_interval_ms_{30000};
+  size_t buffer_size_bytes_{4096};
+  BufferMode buffer_mode_{BUFFER_MODE_LATEST_ONLY};
+
+  std::vector<CoilRegistration> coils_;
+  std::map<uint16_t, size_t> coil_index_;
+  std::vector<PollGroup> poll_groups_;
+  std::map<std::string, size_t> poll_group_index_;
+
+  // Buffer for offline storage
+  std::vector<BufferEntry> history_buffer_;
+  size_t history_head_{0};
+  size_t history_count_{0};
+  std::map<uint16_t, float> latest_buffer_;
+  bool was_connected_{false};
+
+  const char *TAG = "nibegw.poller";
+};
+
+}  // namespace nibegw
+}  // namespace esphome

--- a/components/nibegw/NibeGwCoilSensor.cpp
+++ b/components/nibegw/NibeGwCoilSensor.cpp
@@ -1,0 +1,28 @@
+#include "NibeGwCoilSensor.h"
+#include "NibeGwCoilPoller.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace nibegw {
+
+static const char *TAG = "nibegw.sensor";
+
+void NibeGwCoilSensor::setup() {
+  if (poller_ == nullptr) {
+    ESP_LOGE(TAG, "Poller not set for sensor at address %u", address_);
+    this->mark_failed();
+    return;
+  }
+  poller_->register_coil(address_, static_cast<CoilSize>(coil_size_), factor_, poll_group_,
+                         [this](float value) { this->publish_state(value); });
+}
+
+void NibeGwCoilSensor::dump_config() {
+  LOG_SENSOR("", "NibeGW Coil Sensor", this);
+  ESP_LOGCONFIG(TAG, "  Address: %u", address_);
+  ESP_LOGCONFIG(TAG, "  Size: %u", coil_size_);
+  ESP_LOGCONFIG(TAG, "  Factor: %u", factor_);
+}
+
+}  // namespace nibegw
+}  // namespace esphome

--- a/components/nibegw/NibeGwCoilSensor.h
+++ b/components/nibegw/NibeGwCoilSensor.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+
+namespace esphome {
+namespace nibegw {
+
+class NibeGwCoilPoller;
+
+class NibeGwCoilSensor : public sensor::Sensor, public Component {
+ public:
+  void set_poller(NibeGwCoilPoller *poller) { poller_ = poller; }
+  void set_address(uint16_t address) { address_ = address; }
+  void set_coil_size(uint8_t size) { coil_size_ = size; }
+  void set_factor(uint16_t factor) { factor_ = factor; }
+  void set_poll_group(const std::string &group) { poll_group_ = group; }
+
+  void setup() override;
+  void dump_config() override;
+
+ protected:
+  NibeGwCoilPoller *poller_{nullptr};
+  uint16_t address_{0};
+  uint8_t coil_size_{0};
+  uint16_t factor_{1};
+  std::string poll_group_{"default"};
+};
+
+}  // namespace nibegw
+}  // namespace esphome

--- a/components/nibegw/__init__.py
+++ b/components/nibegw/__init__.py
@@ -10,14 +10,17 @@ from esphome.const import (
 from esphome import pins
 from esphome.components.network import IPAddress
 from enum import IntEnum, Enum
-from esphome.components import uart, socket
+from esphome.components import uart, socket, sensor, number
 from esphome.types import ConfigType
 
-AUTO_LOAD = ["sensor", "climate"]
+AUTO_LOAD = ["sensor", "climate", "number"]
 DEPENDENCIES = ["logger"]
 
 nibegw_ns = cg.esphome_ns.namespace("nibegw")
 NibeGwComponent = nibegw_ns.class_("NibeGwComponent", cg.Component, uart.UARTDevice)
+NibeGwCoilPoller = nibegw_ns.class_("NibeGwCoilPoller", cg.Component)
+NibeGwCoilSensor = nibegw_ns.class_("NibeGwCoilSensor", sensor.Sensor, cg.Component)
+NibeGwCoilNumber = nibegw_ns.class_("NibeGwCoilNumber", number.Number, cg.Component)
 
 CONF_DIR_PIN = "dir_pin"
 CONF_TARGET = "target"
@@ -25,6 +28,7 @@ CONF_TARGET_PORT = "port"
 CONF_TARGET_IP = "ip"
 CONF_ACKNOWLEDGE = "acknowledge"
 CONF_UDP = "udp"
+CONF_ENABLED = "enabled"
 
 CONF_ACKNOWLEDGE_MODBUS40 = "modbus40"
 CONF_ACKNOWLEDGE_RMU40 = "rmu40"
@@ -38,6 +42,23 @@ CONF_TOKEN = "token"
 CONF_COMMAND = "command"
 CONF_DATA = "data"
 CONF_CONSTANTS = "constants"
+
+CONF_SENSORS = "sensors"
+CONF_COILS = "coils"
+CONF_WRITABLE = "writable"
+CONF_SIZE = "size"
+CONF_FACTOR = "factor"
+CONF_POLL_INTERVAL = "poll_interval"
+CONF_BUFFER_SIZE = "buffer_size"
+CONF_BUFFER_MODE = "buffer_mode"
+CONF_MIN_VALUE = "min_value"
+CONF_MAX_VALUE = "max_value"
+CONF_STEP = "step"
+CONF_POLLER_ID = "poller_id"
+CONF_POLL_GROUPS = "poll_groups"
+CONF_POLL_GROUP = "poll_group"
+CONF_INTERVAL = "interval"
+CONF_GROUP_ID = "id"
 
 
 class Addresses(IntEnum):
@@ -73,17 +94,19 @@ def real_enum(enum: Enum):
 
 def _consume_nibegw_sockets(config: ConfigType) -> ConfigType:
     """Register socket needs for nibegw component."""
-    # MQTT needs 1 socket for the broker connection
-    udp = config[CONF_UDP]
-    socket_count = len(udp[CONF_PORTS])
-    socket.consume_sockets(socket_count, "nibegw")(config)
+    udp = config.get(CONF_UDP, {})
+    if udp.get(CONF_ENABLED, False):
+        socket_count = len(udp.get(CONF_PORTS, []))
+        socket.consume_sockets(socket_count, "nibegw")(config)
     return config
 
 
 def _upgrade_ports(config: ConfigType) -> ConfigType:
-    udp = config[CONF_UDP]
-    if port_number := udp[CONF_WRITE_PORT]:
-        udp[CONF_PORTS].insert(
+    udp = config.get(CONF_UDP, {})
+    if not udp.get(CONF_ENABLED, False):
+        return config
+    if port_number := udp.get(CONF_WRITE_PORT):
+        udp.setdefault(CONF_PORTS, []).insert(
             0,
             PORTS_SCHEMA(
                 {
@@ -93,8 +116,8 @@ def _upgrade_ports(config: ConfigType) -> ConfigType:
                 }
             ),
         )
-    if port_number := udp[CONF_READ_PORT]:
-        udp[CONF_PORTS].insert(
+    if port_number := udp.get(CONF_READ_PORT):
+        udp.setdefault(CONF_PORTS, []).insert(
             0,
             PORTS_SCHEMA(
                 {
@@ -107,6 +130,32 @@ def _upgrade_ports(config: ConfigType) -> ConfigType:
 
     return config
 
+
+def _validate_config(config: ConfigType) -> ConfigType:
+    """Validate that at least one feature is enabled."""
+    udp_enabled = config.get(CONF_UDP, {}).get(CONF_ENABLED, True)
+    sensors_enabled = config.get(CONF_SENSORS, {}).get(CONF_ENABLED, False)
+    if not udp_enabled and not sensors_enabled:
+        raise cv.Invalid(
+            "At least one of 'udp.enabled' or 'sensors.enabled' must be true"
+        )
+    return config
+
+
+COIL_SIZES = {
+    "u8": 0,
+    "u16": 1,
+    "s16": 2,
+    "u32": 3,
+    "s32": 4,
+    "s8": 5,
+}
+
+BUFFER_MODES = {
+    "off": 0,
+    "latest_only": 1,
+    "history": 2,
+}
 
 CONSTANTS_SCHEMA = cv.Schema(
     {
@@ -134,11 +183,53 @@ PORTS_SCHEMA = cv.Schema(
 
 UDP_SCHEMA = cv.Schema(
     {
+        cv.Optional(CONF_ENABLED, default=True): cv.boolean,
         cv.Optional(CONF_TARGET, []): cv.ensure_list(TARGET_SCHEMA),
         cv.Optional(CONF_READ_PORT, default=9999): cv.port,
         cv.Optional(CONF_WRITE_PORT, default=10000): cv.port,
         cv.Optional(CONF_SOURCE, []): cv.ensure_list(cv.ipv4address),
         cv.Optional(CONF_PORTS, []): cv.ensure_list(PORTS_SCHEMA),
+    }
+)
+
+POLL_GROUP_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_GROUP_ID): cv.All(cv.string_strict, cv.Length(min=1)),
+        cv.Required(CONF_INTERVAL): cv.positive_time_period_milliseconds,
+    }
+)
+
+COIL_SENSOR_SCHEMA = sensor.sensor_schema(NibeGwCoilSensor).extend(
+    {
+        cv.Required(CONF_ADDRESS): cv.uint16_t,
+        cv.Required(CONF_SIZE): cv.enum(COIL_SIZES, lower=True),
+        cv.Optional(CONF_FACTOR, default=1): cv.positive_int,
+        cv.Optional(CONF_POLL_GROUP, default="default"): cv.string_strict,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+COIL_NUMBER_SCHEMA = number.number_schema(NibeGwCoilNumber).extend(
+    {
+        cv.Required(CONF_ADDRESS): cv.uint16_t,
+        cv.Required(CONF_SIZE): cv.enum(COIL_SIZES, lower=True),
+        cv.Optional(CONF_FACTOR, default=1): cv.positive_int,
+        cv.Required(CONF_MIN_VALUE): cv.float_,
+        cv.Required(CONF_MAX_VALUE): cv.float_,
+        cv.Optional(CONF_STEP, default=1.0): cv.positive_float,
+        cv.Optional(CONF_POLL_GROUP, default="default"): cv.string_strict,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+SENSORS_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_ENABLED, default=False): cv.boolean,
+        cv.GenerateID(CONF_POLLER_ID): cv.declare_id(NibeGwCoilPoller),
+        cv.Optional(CONF_POLL_INTERVAL, default="30s"): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_POLL_GROUPS, default=[]): cv.ensure_list(POLL_GROUP_SCHEMA),
+        cv.Optional(CONF_BUFFER_SIZE, default=4096): cv.int_range(min=0, max=65536),
+        cv.Optional(CONF_BUFFER_MODE, default="latest_only"): cv.enum(BUFFER_MODES, lower=True),
+        cv.Optional(CONF_COILS, default=[]): cv.ensure_list(COIL_SENSOR_SCHEMA),
+        cv.Optional(CONF_WRITABLE, default=[]): cv.ensure_list(COIL_NUMBER_SCHEMA),
     }
 )
 
@@ -149,7 +240,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ACKNOWLEDGE, default=[]): [
                 cv.Any(addresses_string, cv.Coerce(int))
             ],
-            cv.Required(CONF_UDP): UDP_SCHEMA,
+            cv.Optional(CONF_UDP, default={}): UDP_SCHEMA,
+            cv.Optional(CONF_SENSORS, default={}): SENSORS_SCHEMA,
             cv.Optional(CONF_DIR_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_CONSTANTS, default=[]): cv.ensure_list(CONSTANTS_SCHEMA),
         }
@@ -158,10 +250,11 @@ CONFIG_SCHEMA = cv.All(
     .extend(uart.UART_DEVICE_SCHEMA),
     _upgrade_ports,
     _consume_nibegw_sockets,
+    _validate_config,
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     if dir_pin := config.get(CONF_DIR_PIN):
         dir_pin_data = await cg.gpio_pin_expression(dir_pin)
     else:
@@ -174,28 +267,32 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
-    if udp := config.get(CONF_UDP):
-        for target in udp[CONF_TARGET]:
+    # ── UDP Gateway ──
+    udp = config.get(CONF_UDP, {})
+    if udp.get(CONF_ENABLED, False):
+        for target in udp.get(CONF_TARGET, []):
             cg.add(
                 var.add_target(
                     IPAddress(str(target[CONF_TARGET_IP])), target[CONF_TARGET_PORT]
                 )
             )
 
-        for port in udp[CONF_PORTS]:
+        for port in udp.get(CONF_PORTS, []):
             cg.add(
                 var.add_socket_request(
                     port[CONF_ADDRESS], port[CONF_TOKEN], port[CONF_PORT]
                 )
             )
 
-        for source in udp[CONF_SOURCE]:
+        for source in udp.get(CONF_SOURCE, []):
             cg.add(var.add_source_ip(IPAddress(str(source))))
 
+    # ── Acknowledge ──
     if config[CONF_ACKNOWLEDGE]:
         for address in config[CONF_ACKNOWLEDGE]:
             cg.add(var.add_acknowledge(address))
 
+    # ── Constants ──
     def xor8(data: bytes) -> int:
         chksum = reduce(xor, data)
         if chksum == 0x5C:
@@ -213,3 +310,42 @@ async def to_code(config):
             request[CONF_DATA],
         )
         cg.add(var.set_request(request[CONF_ADDRESS], request[CONF_TOKEN], data))
+
+    # ── Sensors (direct coil polling) ──
+    sensors_conf = config.get(CONF_SENSORS, {})
+    if sensors_conf.get(CONF_ENABLED, False):
+        poller = cg.new_Pvariable(sensors_conf[CONF_POLLER_ID])
+        await cg.register_component(poller, sensors_conf)
+        cg.add(poller.set_gw(var))
+        cg.add(poller.set_poll_interval(sensors_conf[CONF_POLL_INTERVAL]))
+        cg.add(poller.set_buffer_size(sensors_conf[CONF_BUFFER_SIZE]))
+        cg.add(poller.set_buffer_mode(sensors_conf[CONF_BUFFER_MODE]))
+
+        # Register explicit poll groups
+        for group_conf in sensors_conf.get(CONF_POLL_GROUPS, []):
+            cg.add(poller.add_poll_group(group_conf[CONF_GROUP_ID], group_conf[CONF_INTERVAL]))
+
+        for coil_conf in sensors_conf.get(CONF_COILS, []):
+            sens = await sensor.new_sensor(coil_conf)
+            await cg.register_component(sens, coil_conf)
+            cg.add(sens.set_poller(poller))
+            cg.add(sens.set_address(coil_conf[CONF_ADDRESS]))
+            cg.add(sens.set_coil_size(coil_conf[CONF_SIZE]))
+            cg.add(sens.set_factor(coil_conf[CONF_FACTOR]))
+            cg.add(sens.set_poll_group(coil_conf[CONF_POLL_GROUP]))
+
+        for num_conf in sensors_conf.get(CONF_WRITABLE, []):
+            num = await number.new_number(
+                num_conf,
+                min_value=num_conf[CONF_MIN_VALUE],
+                max_value=num_conf[CONF_MAX_VALUE],
+                step=num_conf[CONF_STEP],
+            )
+            await cg.register_component(num, num_conf)
+            cg.add(num.set_gw(var))
+            cg.add(num.set_poller(poller))
+            cg.add(num.set_address(num_conf[CONF_ADDRESS]))
+            cg.add(num.set_coil_size(num_conf[CONF_SIZE]))
+            cg.add(num.set_factor(num_conf[CONF_FACTOR]))
+            cg.add(num.set_poll_group(num_conf[CONF_POLL_GROUP]))
+            cg.add(poller.register_writable(num))

--- a/components/nibegw/climate.py
+++ b/components/nibegw/climate.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import climate, sensor
 from esphome.const import CONF_SENSOR
+from esphome.types import ConfigType
 from . import NibeGwComponent, nibegw_ns
 
 AUTO_LOAD = ["sensor"]
@@ -24,7 +25,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await climate.new_climate(config)
     await cg.register_component(var, config)
     gw = await cg.get_variable(config[CONF_GATEWAY])

--- a/docs/MQTT_SENSORS.md
+++ b/docs/MQTT_SENSORS.md
@@ -1,0 +1,418 @@
+# NibeGW Direct Sensor Polling via MQTT
+
+Publish Nibe heat pump coil values directly from the ESP32 to an MQTT broker, with Home Assistant auto-discovery. This eliminates the need for an external gateway like [nibe-mqtt](https://github.com/yozik04/nibe-mqtt).
+
+## Why use this?
+
+The traditional setup requires a separate service (e.g. nibe-mqtt in Docker) to bridge UDP to MQTT. With direct sensor polling:
+
+- **No external dependencies** - the ESP32 handles everything
+- **Network resilience** - RS485 communication continues even when MQTT/network is down
+- **Buffering** - coil values are stored during MQTT outages and flushed on reconnect
+- **Simpler deployment** - one device, one config file
+
+## Prerequisites
+
+- ESPHome 2026.3.0 or later
+- An MQTT broker (e.g. Mosquitto) reachable from the ESP32
+- Your Nibe heat pump model's coil addresses (see [Finding coil addresses](#finding-coil-addresses))
+
+## Configuration
+
+The `nibegw` component has two independently enabled features:
+
+| Feature | Purpose |
+|---|---|
+| `udp` | Forward raw data to external tools (classic NibeGW mode) |
+| `sensors` | Poll specific coils and publish directly to MQTT |
+
+Both can be enabled simultaneously, or just one.
+
+### Minimal example (sensors only)
+
+```yaml
+mqtt:
+  broker: 192.168.1.2
+  username: user
+  password: pass
+  discovery: true
+
+nibegw:
+  acknowledge:
+    - MODBUS40
+  constants:
+    - address: MODBUS40
+      token: ACCESSORY
+      data: [0x0A, 0x00, 0x01]
+
+  udp:
+    enabled: false
+
+  sensors:
+    enabled: true
+    poll_interval: 30s
+    poll_groups:
+      - id: fast
+        interval: 10s
+      - id: slow
+        interval: 120s
+    coils:
+      - name: "BT1 Outdoor Temperature"
+        address: 40004
+        size: s16
+        factor: 10
+        unit_of_measurement: "°C"
+        device_class: temperature
+        accuracy_decimals: 1
+        poll_group: fast
+      - name: "Energy Heating"
+        address: 44300
+        size: u32
+        factor: 10
+        unit_of_measurement: "kWh"
+        device_class: energy
+        accuracy_decimals: 1
+        poll_group: slow
+```
+
+### Dual mode (UDP + sensors)
+
+```yaml
+nibegw:
+  acknowledge:
+    - MODBUS40
+  constants:
+    - address: MODBUS40
+      token: ACCESSORY
+      data: [0x0A, 0x00, 0x01]
+
+  udp:
+    enabled: true
+    target:
+      - ip: 192.168.1.10
+        port: 9999
+    source:
+      - 192.168.1.10
+    read_port: 9999
+    write_port: 10000
+
+  sensors:
+    enabled: true
+    poll_interval: 30s
+    coils:
+      - name: "BT1 Outdoor Temperature"
+        address: 40004
+        size: s16
+        factor: 10
+        unit_of_measurement: "°C"
+        device_class: temperature
+        accuracy_decimals: 1
+```
+
+### UDP only (classic mode)
+
+```yaml
+nibegw:
+  acknowledge:
+    - MODBUS40
+  constants:
+    - address: MODBUS40
+      token: ACCESSORY
+      data: [0x0A, 0x00, 0x01]
+
+  udp:
+    enabled: true
+    target:
+      - ip: 192.168.1.10
+        port: 9999
+    read_port: 9999
+    write_port: 10000
+
+  sensors:
+    enabled: false
+```
+
+## Configuration reference
+
+### `sensors:` block
+
+| Option | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Enable direct coil polling |
+| `poll_interval` | `30s` | Default interval for poll groups not explicitly defined |
+| `poll_groups` | `[]` | Named poll groups with custom intervals (see below) |
+| `buffer_size` | `4096` | Circular buffer size in bytes for MQTT-offline storage (0 = disabled) |
+| `buffer_mode` | `latest_only` | `latest_only`, `history`, or `off` (see [Buffer behavior](#buffer-behavior)) |
+| `coils` | `[]` | List of read-only coil sensors |
+| `writable` | `[]` | List of writable coil number entities |
+
+### `poll_groups[]` entries
+
+| Option | Required | Description |
+|---|---|---|
+| `id` | yes | Group name (referenced by `poll_group` on coils) |
+| `interval` | yes | Poll interval for this group (e.g. `10s`, `30s`, `120s`) |
+
+Coils without an explicit `poll_group` are assigned to `"default"`, which uses `poll_interval`.
+Groups referenced by coils but not defined in `poll_groups` are auto-created with `poll_interval`.
+
+### `coils[]` entries (read-only sensors)
+
+| Option | Required | Description |
+|---|---|---|
+| `name` | yes | Sensor name (appears in HA) |
+| `address` | yes | Nibe coil address (e.g. `40004`) |
+| `size` | yes | Data type: `u8`, `s8`, `u16`, `s16`, `u32`, `s32` |
+| `factor` | no (default: 1) | Raw value is divided by this (e.g. factor 10 means raw 215 = 21.5) |
+| `poll_group` | no (default: `"default"`) | Which poll group this coil belongs to |
+| `unit_of_measurement` | no | Unit string for HA (e.g. `"°C"`, `"Hz"`) |
+| `device_class` | no | HA device class (e.g. `temperature`, `frequency`, `power`) |
+| `accuracy_decimals` | no | Decimal places shown in HA |
+
+### `writable[]` entries (number entities)
+
+Same as `coils[]` plus:
+
+| Option | Required | Description |
+|---|---|---|
+| `min_value` | yes | Minimum allowed value |
+| `max_value` | yes | Maximum allowed value |
+| `step` | no (default: 1.0) | Step size for the number entity |
+
+### Write behavior
+
+Writable coils appear as `number` entities in HA, controllable via MQTT command topic or the web dashboard.
+
+**Write flow:**
+1. Value is sent to the heat pump as a MODBUS write request (0x6B)
+2. The pump confirms or denies the write (0x6C response)
+3. On success: a read-back request is queued to verify the value from the pump
+4. On denial: a warning is logged (the pump rejects writes to read-only or out-of-range values)
+5. Write timeout: 10 seconds - if no response, the write is considered failed
+
+**Initial value on boot:**
+Writable coils queue an initial read request 5 seconds after boot to fetch the current value from the pump. This means the number entity shows the actual pump setting shortly after startup, without needing to write first.
+
+**Queue behavior:**
+Read and write requests share the RS485 bus with regular sensor polling. The Nibe protocol processes one request per token cycle (~2 seconds). Requests are served FIFO with a queue depth of 3 per token type. In practice:
+- Write requests use WRITE_TOKEN (0x6B) - separate queue from reads
+- Read-after-write uses READ_TOKEN (0x69) - shares queue with sensor polling
+- With many sensors polling, a read-back may take a few seconds to be served
+
+**Important:** Only configure coils marked with `"write": true` in the coil database. Writing to read-only coils will be denied by the pump.
+
+## Finding coil addresses
+
+Coil definitions for each Nibe model are maintained in the [nibe](https://github.com/yozik04/nibe) library under [`nibe/data/`](https://github.com/yozik04/nibe/tree/master/nibe/data).
+
+### Step 1: Find your model's JSON file
+
+| Model | File |
+|---|---|
+| F1155 / F1255 | `f1155_f1255.json` |
+| F1145 / F1245 | `f1145_f1245.json` |
+| F730 | `f730.json` |
+| F750 | `f750.json` |
+| S1156 / S1256 | `s1156_s1256.json` |
+| SMO40 | `smo40.json` |
+
+### Step 2: Look up a coil and map to YAML
+
+Each JSON entry looks like:
+
+```json
+"40004": {
+  "title": "BT1 Outdoor Temperature",
+  "info": "Current outdoor temperature",
+  "unit": "°C",
+  "size": "s16",
+  "factor": 10,
+  "name": "bt1-outdoor-temperature-40004"
+}
+```
+
+Map it to YAML:
+
+```yaml
+- name: "BT1 Outdoor Temperature"    # ← title
+  address: 40004                       # ← JSON key
+  size: s16                            # ← size
+  factor: 10                           # ← factor (raw value ÷ factor = displayed value)
+  unit_of_measurement: "°C"            # ← unit
+  device_class: temperature            # ← you choose based on the unit
+  accuracy_decimals: 1                 # ← you choose (factor 10 → 1 decimal)
+```
+
+### Step 3: Writable coils
+
+Writable coils have `"write": true` and `min`/`max` fields in the JSON:
+
+```json
+"47011": {
+  "title": "Heat Offset S1",
+  "size": "s8",
+  "factor": 1,
+  "min": -10.0,
+  "max": 10.0,
+  "write": true,
+  "name": "heat-offset-s1-47011"
+}
+```
+
+Map to YAML under `writable:`:
+
+```yaml
+writable:
+  - name: "Heat Offset S1"
+    address: 47011
+    size: s8
+    factor: 1
+    min_value: -10
+    max_value: 10
+    step: 1
+```
+
+## Buffer behavior
+
+When MQTT is disconnected (e.g. broker down, network loss), the ESP32 continues polling the heat pump. Coil values are stored in a configurable buffer and published when MQTT reconnects.
+
+### `buffer_mode: latest_only` (default)
+
+Stores only the most recent value per coil. On reconnect, each coil publishes its last known value. Uses minimal RAM (~8 bytes per coil).
+
+### `buffer_mode: history`
+
+Stores timestamped values in a circular ring buffer. On reconnect, all buffered entries are published oldest-first. Buffer capacity depends on `buffer_size`:
+
+| `buffer_size` | Entries (~12 bytes each) | Duration (20 coils @ 30s) |
+|---|---|---|
+| `1024` | ~85 | ~2 min |
+| `4096` | ~341 | ~8.5 min |
+| `16384` | ~1365 | ~34 min |
+| `65536` | ~5461 | ~2.3 hours |
+
+### `buffer_mode: off`
+
+No buffering. Values during MQTT outage are lost.
+
+## Migrating from nibe-mqtt
+
+If you currently use [nibe-mqtt](https://github.com/yozik04/nibe-mqtt), here's how to migrate:
+
+### 1. Map your poll coils
+
+Your nibe-mqtt `config.yaml`:
+
+```yaml
+nibe:
+  model: F1155
+  poll:
+    coils:
+      - bt1-outdoor-temperature-40004
+      - bt7-hw-top-40013
+      - compressor-frequency-actual-43136
+```
+
+The `name` field in the JSON database (e.g. `bt1-outdoor-temperature-40004`) is the same identifier nibe-mqtt uses. Look up each one in the JSON file to get the address, size, and factor.
+
+### 2. Add them to your ESPHome config
+
+```yaml
+sensors:
+  enabled: true
+  coils:
+    - name: "BT1 Outdoor Temperature"
+      address: 40004
+      size: s16
+      factor: 10
+      unit_of_measurement: "°C"
+      device_class: temperature
+      accuracy_decimals: 1
+    - name: "BT7 HW Top"
+      address: 40013
+      size: s16
+      factor: 10
+      unit_of_measurement: "°C"
+      device_class: temperature
+      accuracy_decimals: 1
+    - name: "Compressor Frequency"
+      address: 43136
+      size: u16
+      factor: 10
+      unit_of_measurement: "Hz"
+      accuracy_decimals: 1
+```
+
+### 3. Add MQTT config
+
+Replace `api:` with `mqtt:` in your ESPHome config:
+
+```yaml
+mqtt:
+  broker: your_mqtt_broker
+  username: your_user
+  password: your_pass
+  discovery: true
+```
+
+### 4. Disable UDP if no longer needed
+
+Set `udp.enabled: false` if you're no longer running nibe-mqtt.
+
+### 5. Stop the nibe-mqtt container
+
+Once verified, stop and remove the Docker container.
+
+## Optional: Web dashboard and diagnostics
+
+ESPHome has a built-in web server that shows live sensor values - useful for quick checks without HA:
+
+```yaml
+web_server:
+  port: 80
+```
+
+Access it at `http://<esp32-ip>/`. All coil sensors appear automatically.
+
+To monitor memory usage (useful for tuning `buffer_size`):
+
+```yaml
+debug:
+  update_interval: 30s
+
+sensor:
+  - platform: debug
+    free:
+      name: "Free Heap Memory"
+    loop_time:
+      name: "Loop Time"
+```
+
+These show up on both the web dashboard and in MQTT/HA.
+
+## Troubleshooting
+
+### No sensor data appearing
+
+- Check ESPHome logs for `"Coil xxxx = ..."` messages (set log level to DEBUG)
+- Verify `acknowledge: [MODBUS40]` is set
+- Verify the MODBUS40 accessory constant is configured
+- Check that the coil address exists for your heat pump model
+
+### Wrong values / garbage data
+
+- Check the `size` field matches the JSON database (e.g. `s16` vs `u16`)
+- Check the `factor` field - wrong factor gives values 10x or 100x off
+- Some coils use `s8` which is padded to 2 bytes in the protocol
+
+### MQTT not connecting
+
+- Verify broker IP is reachable from the ESP32
+- Check credentials
+- ESPHome's `mqtt:` and `api:` cannot be used simultaneously - remove/comment out `api:`
+
+### Buffer not flushing on reconnect
+
+- Check logs for `"MQTT reconnected, flushing buffer"`
+- Verify `buffer_mode` is not `off`
+- `buffer_size: 0` also disables buffering


### PR DESCRIPTION
## Summary

Add an optional sensor polling feature that publishes Nibe heat pump coil values directly to MQTT from the ESP32, with Home Assistant auto-discovery. This eliminates the need for an external [nibe-mqtt](https://github.com/yozik04/nibe-mqtt) Docker container.

**Depends on:** #157 (protocol enums), #158 (component improvements)

### Why?

The current architecture requires a separate service (nibe-mqtt) to bridge UDP→MQTT. With direct polling:
- **No external dependencies** - the ESP32 handles everything
- **Network resilience** - RS485 communication continues when MQTT/network is down
- **Buffering** - coil values stored during outages, flushed on reconnect
- **Simpler deployment** - one device, one config

### How it works

The Nibe protocol uses a token-based polling mechanism:
1. Heat pump sends READ_TOKEN request (0x69, len=0): "what do you want to read?"
2. Gateway responds with one coil address: `[C0 69 02 addr_lo addr_hi chk]`
3. Heat pump sends MODBUS_READ_RESP (0x6A): `[5C 00 20 6A 06 addr val4bytes chk]`

The poller also listens on MODBUS_DATA_MSG (0x68) for the pump's periodic broadcasts.

### Configuration

```yaml
nibegw:
  udp:
    enabled: false  # or true for dual mode
  sensors:
    enabled: true
    poll_interval: 30s
    poll_groups:
      - id: fast
        interval: 10s
      - id: slow
        interval: 120s
    buffer_size: 8192
    buffer_mode: latest_only
    coils:
      - name: "BT1 Outdoor Temperature"
        address: 40004
        size: s16
        factor: 10
        unit_of_measurement: "°C"
        device_class: temperature
        poll_group: fast
      - name: "Energy Heating"
        address: 44300
        size: u32
        factor: 10
        unit_of_measurement: "kWh"
        device_class: energy
        poll_group: slow
```

### Poll groups

Coils are assigned to named groups with independent intervals. Each group queues up to 3 requests per tick, with queue-aware throttling to prevent fast groups from starving slower ones.

| Group | Interval | Example coils | Cycle time (44 coils) |
|-------|----------|---------------|----------------------|
| fast | 10s | BT1, BT6, BT7, compressor freq | 10s (4 coils) |
| default | 30s | temperatures, pumps, status | ~7 min |
| slow | 120s | energy meters, runtime counters | ~10 min |

### Buffer for MQTT outages

When MQTT disconnects, coil values accumulate in a configurable buffer:
- `latest_only`: stores last value per coil (~8 bytes per coil)
- `history`: timestamped circular ring buffer (12 bytes per entry)
- Automatic flush on MQTT reconnect

### New files
- `NibeGwCoilPoller.h/cpp` - Polling coordinator, data parser, buffer management
- `NibeGwCoilSensor.h/cpp` - Per-coil ESPHome sensor entity
- `docs/MQTT_SENSORS.md` - Complete usage guide with coil database mapping, migration from nibe-mqtt, troubleshooting
- `compile.sh` - Memory-safe build script (limits parallel jobs for WSL)

### Modified files
- `__init__.py` - Added sensors schema, poll_groups, enabled flags, type hints
- `climate.py` - Added type hints

### Testing

Tested on ESP32-C3 with DM9051 Ethernet + Nibe F1155 + PCM42 (4-pipe passive cooling):
- 53 read-only coils across 3 poll groups
- All coil values verified against heat pump display
- MQTT publishing to Mosquitto with HA auto-discovery
- Web dashboard (ESPHome web_server) showing live values
- Both UDP+sensors and sensors-only modes tested
- Network disconnect/reconnect with buffer flush verified

### RAM/Flash impact
- RAM: +1.7KB (sensors + poller structures)
- Flash: +135KB (MQTT + sensor + number components)

🤖 Generated with [Claude Code](https://claude.com/claude-code)