### PR TITLE
fix: validate token response checksum before sending to RS485

### DIFF
--- a/components/nibegw/NibeGw.cpp
+++ b/components/nibegw/NibeGw.cpp
@@ -185,9 +185,14 @@ void NibeGw::handleMsgReceived() {
     if (len == 0) {
       int msglen = callback_msg_token_received(address, command, &buffer[index]);
       if (msglen > 0) {
-        sendData(&buffer[index], msglen);
-        index += msglen;
-        state = STATE_WAIT_ACK;
+        if (checkSlaveData(&buffer[index], msglen) == PACKET_OK) {
+          sendData(&buffer[index], msglen);
+          index += msglen;
+          state = STATE_WAIT_ACK;
+        } else {
+          ESP_LOGW(TAG, "Dropping invalid token response for 0x%x:0x%x (%d bytes)", address, command, msglen);
+          stateCompleteAck();
+        }
       } else {
         stateCompleteAck();
       }


### PR DESCRIPTION
## Summary

Validate the integrity of slave response packets before sending them on the RS485 bus to the heat pump. This prevents corrupted or malformed data from reaching the pump.

### Problem

When the heat pump sends a token request (len=0), `callback_msg_token_received()` provides response data from queued requests or static providers. This data is sent directly via `sendData()` **without any validation**. If the data is corrupted (e.g. from a UDP source, or a bug in a response provider), malformed bytes are sent to the pump.

### Fix

Call the existing `checkSlaveData()` function on the response before sending. This validates:
- Start byte (0xC0)
- Payload length field matches actual data
- XOR checksum is correct

On validation failure: log a warning and send a plain ACK instead of the bad data. The pump sees "no data available" rather than garbage.

### Why this matters

- UDP packets from external tools (e.g. nibe-mqtt) could be corrupted in transit
- Internal response providers (sensor polling, climate) could theoretically produce bad packets
- Sending bad checksums to the pump can cause communication errors or unexpected behavior
- `checkSlaveData()` already validates UDP-received packets in `recv_local_socket()` — this extends the same protection to all token responses

### Changes

`NibeGw.cpp`: 5 lines added in `handleMsgReceived()` — wraps the existing `sendData()` call with a `checkSlaveData()` check.

### Testing

Tested on ESP32-C3 + Nibe F1155:
- All read responses pass validation (no warnings logged)
- Write responses pass validation
- Normal sensor polling unaffected
- No performance impact (checksum calculation is a simple XOR over the packet)

### Related

This addresses the same concern as #15 (Verify token checksum data), reimplemented against the current codebase. The original PR was written against the old AsyncUDP/byte API which no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)